### PR TITLE
more asConjure for tracing 

### DIFF
--- a/tracing/build.gradle
+++ b/tracing/build.gradle
@@ -4,6 +4,7 @@ apply from: "$rootDir/gradle/publish-jar.gradle"
 
 dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
+    compile "com.palantir.tracing:tracing-api"
 
     testCompile "junit:junit"
     testCompile "org.assertj:assertj-core"

--- a/tracing/src/main/java/com/palantir/remoting/api/tracing/OpenSpan.java
+++ b/tracing/src/main/java/com/palantir/remoting/api/tracing/OpenSpan.java
@@ -61,6 +61,18 @@ public abstract class OpenSpan {
     /** Indicates the {@link SpanType} of this span, e.g., a server-side vs. client-side vs local span. */
     public abstract SpanType type();
 
+    @Value.Lazy
+    public com.palantir.tracing.api.OpenSpan asConjure() {
+        return com.palantir.tracing.api.OpenSpan.builder()
+                .operation(getOperation())
+                .spanId(getSpanId())
+                .parentSpanId(getParentSpanId())
+                .type(type().asConjure())
+                .startClockNanoSeconds(getStartClockNanoSeconds())
+                .startTimeMicroSeconds(getStartTimeMicroSeconds())
+                .build();
+    }
+
     /**
      * Indicates if this trace state was sampled public abstract boolean isSampled();
      * <p>
@@ -76,4 +88,5 @@ public abstract class OpenSpan {
     }
 
     public static class Builder extends ImmutableOpenSpan.Builder {}
+
 }

--- a/tracing/src/main/java/com/palantir/remoting/api/tracing/Span.java
+++ b/tracing/src/main/java/com/palantir/remoting/api/tracing/Span.java
@@ -44,6 +44,20 @@ public abstract class Span {
      */
     public abstract Map<String, String> getMetadata();
 
+    @Value.Lazy
+    public com.palantir.tracing.api.Span asConjure() {
+        return com.palantir.tracing.api.Span.builder()
+                .traceId(getTraceId())
+                .parentSpanId(getParentSpanId())
+                .spanId(getSpanId())
+                .type(type().asConjure())
+                .operation(getOperation())
+                .startTimeMicroSeconds(getStartTimeMicroSeconds())
+                .durationNanoSeconds(getDurationNanoSeconds())
+                .metadata(getMetadata())
+                .build();
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/tracing/src/main/java/com/palantir/remoting/api/tracing/SpanObserver.java
+++ b/tracing/src/main/java/com/palantir/remoting/api/tracing/SpanObserver.java
@@ -22,4 +22,6 @@ package com.palantir.remoting.api.tracing;
  */
 public interface SpanObserver {
     void consume(Span span);
+
+    com.palantir.tracing.api.SpanObserver asConjure();
 }

--- a/tracing/src/main/java/com/palantir/remoting/api/tracing/SpanType.java
+++ b/tracing/src/main/java/com/palantir/remoting/api/tracing/SpanType.java
@@ -30,5 +30,19 @@ public enum SpanType {
     CLIENT_OUTGOING,
 
     /** Indicates a local method call or computation that does not involve RPC. */
-    LOCAL
+    LOCAL;
+
+    public com.palantir.tracing.api.SpanType asConjure() {
+        switch (this) {
+            case SERVER_INCOMING:
+                return com.palantir.tracing.api.SpanType.SERVER_INCOMING;
+            case CLIENT_OUTGOING:
+                return com.palantir.tracing.api.SpanType.CLIENT_OUTGOING;
+            case LOCAL:
+                return com.palantir.tracing.api.SpanType.LOCAL;
+        }
+
+        throw new UnsupportedOperationException("Unable to convert to Conjure SpanType");
+    }
+
 }

--- a/versions.props
+++ b/versions.props
@@ -4,6 +4,7 @@ com.google.guava:guava = 18.0
 com.palantir.safe-logging:safe-logging = 0.1.3
 com.palantir.tokens:auth-tokens = 3.0.0
 com.palantir.conjure.java.api:* = 2.0.0-rc7
+com.palantir.tracing:tracing-api = 1.1.0
 javax.ws.rs:javax.ws.rs-api = 2.0.1
 junit:junit = 4.12
 org.apache.commons:commons-lang3 = 3.6


### PR DESCRIPTION
expose more asConjure for tracing in order to delegate all remoting tracer calls to `tracing-java`, so both remoting and new tracer share the same threadlocal.