### PR TITLE
[fix] SerializableError#asConjure() handles both remoting2 and remoting3 JSON keys

### DIFF
--- a/errors/src/main/java/com/palantir/remoting/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/remoting/api/errors/SerializableError.java
@@ -119,15 +119,14 @@ public abstract class SerializableError implements Serializable {
         com.palantir.conjure.java.api.errors.SerializableError.Builder builder =
                 com.palantir.conjure.java.api.errors.SerializableError.builder();
 
-        if (!getExceptionClass().isPresent()) {
-            builder.errorCode(errorCode());
-            builder.errorName(errorName());
-        } else {
+        if (getExceptionClass().isPresent()) {
             // this is for back-compat, old remoting2 exceptions have 'exceptionClass' and 'message' fields.
             builder.exceptionClass(getExceptionClass().get());
             builder.message(getMessage().get());
         }
 
+        builder.errorName(errorName());
+        builder.errorCode(errorCode());
         builder.errorInstanceId(errorInstanceId());
 
         return builder.build();

--- a/errors/src/main/java/com/palantir/remoting/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/remoting/api/errors/SerializableError.java
@@ -128,6 +128,7 @@ public abstract class SerializableError implements Serializable {
         builder.errorName(errorName());
         builder.errorCode(errorCode());
         builder.errorInstanceId(errorInstanceId());
+        builder.parameters(parameters());
 
         return builder.build();
     }

--- a/errors/src/test/java/com/palantir/remoting/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/remoting/api/errors/SerializableErrorTest.java
@@ -134,11 +134,14 @@ public final class SerializableErrorTest {
     @Test
     public void asConjure_converts_json_with_both_remoting2_and_remoting3_fields() throws IOException {
         assertThat(deserialize("{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
-                + "\"exceptionClass\":\"java.lang.IllegalStateException\",\"message\":\"Human readable message\"}")
+                + "\"exceptionClass\":\"java.lang.IllegalStateException\",\"message\":\"Human readable message\","
+                + "\"errorInstanceId\":\"7d345390-e41d-49dd-8dcb-38dd716c0347\",\"parameters\":{\"a\":\"1\"}}")
                 .asConjure())
                 .isEqualTo(com.palantir.conjure.java.api.errors.SerializableError.builder()
                         .errorCode("PERMISSION_DENIED")
                         .errorName("Product:SomethingBroke")
+                        .errorInstanceId("7d345390-e41d-49dd-8dcb-38dd716c0347")
+                        .putParameters("a", "1")
                         .build());
     }
 

--- a/errors/src/test/java/com/palantir/remoting/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/remoting/api/errors/SerializableErrorTest.java
@@ -117,6 +117,17 @@ public final class SerializableErrorTest {
                         .build());
     }
 
+    @Test
+    public void asConjure_converts_json_with_both_remoting2_and_remoting3_fields() throws IOException {
+        assertThat(deserialize("{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
+                + "\"exceptionClass\":\"java.lang.IllegalStateException\",\"message\":\"Human readable message\"}")
+                .asConjure())
+                .isEqualTo(com.palantir.conjure.java.api.errors.SerializableError.builder()
+                        .errorCode("PERMISSION_DENIED")
+                        .errorName("Product:SomethingBroke")
+                        .build());
+    }
+
     private static SerializableError deserialize(String serialized) throws IOException {
         return mapper.readValue(serialized, SerializableError.class);
     }


### PR DESCRIPTION
## Before this PR

asConjure would return a broken result if a server returns json with both remoting2 and remoting2 types, e.g.:

```json
{
    "errorCode":"CONFLICT",
    "errorName":"Product:TransactionConflict",
    "errorInstanceId":"7d345390-e41d-49dd-8dcb-38dd716c0347",
    "parameters":{},
    "exceptionClass":"CONFLICT",
    "message":"Refer to the server logs with this errorInstanceId: 7d345390-e41d-49dd-8dcb-38dd716c0347"
}
```

It would translate this into the broken:
```json
{
    "errorCode":"CONFLICT",
    "errorName":"Refer to the server logs with this errorInstanceId: 7d345390-e41d-49dd-8dcb-38dd716c0347",
    "errorInstanceId":"7d345390-e41d-49dd-8dcb-38dd716c0347",
    "parameters":{}
}
```

## After this PR

It translates it into the correct SerializableError.


## Open questions

- how can we actually publish this, now that our bintray creds point to the wrong place???