### PR TITLE
[improvement] Add HostEventsSink

### DIFF
--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/HostEventsSink.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/HostEventsSink.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.config.service;
+
+/**
+ * A listener for responses / exceptions coming from remote hosts, used by clients created using conjure-java-runtime.
+ */
+public interface HostEventsSink {
+    void record(String serviceName, String hostname, int port, int statusCode, long micros);
+
+    void recordIoException(String serviceName, String hostname, int port);
+}


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

## After this PR
<!-- Describe at a high-level why this approach is better. -->

Ported `HostEventsSink` which is currently defined in [conjure-java-runtime's okhttp-clients package](https://github.com/palantir/conjure-java-runtime/blob/987f2936bbf3d844a40568d2f8e3e3f6e0363c3c/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java).

Will follow-up by making that interface extend this one.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
