### PR TITLE
Remove unnecessary dependency on javax.ws.rs-api

### DIFF
--- a/errors/build.gradle
+++ b/errors/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
     compile "com.google.code.findbugs:jsr305"
     compile "com.palantir.safe-logging:safe-logging"
-    compile "javax.ws.rs:javax.ws.rs-api"
     implementation "com.palantir.safe-logging:preconditions"
 
     testCompile project(":extras:jackson-support")

--- a/errors/versions.lock
+++ b/errors/versions.lock
@@ -32,9 +32,6 @@
             "transitive": [
                 "com.palantir.safe-logging:preconditions"
             ]
-        },
-        "javax.ws.rs:javax.ws.rs-api": {
-            "locked": "2.0.1"
         }
     },
     "runtime": {
@@ -58,9 +55,6 @@
         },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.5.0"
-        },
-        "javax.ws.rs:javax.ws.rs-api": {
-            "locked": "2.0.1"
         }
     }
 }

--- a/test-utils/versions.lock
+++ b/test-utils/versions.lock
@@ -33,12 +33,6 @@
                 "com.palantir.conjure.java.api:errors"
             ]
         },
-        "javax.ws.rs:javax.ws.rs-api": {
-            "locked": "2.0.1",
-            "transitive": [
-                "com.palantir.conjure.java.api:errors"
-            ]
-        },
         "junit:junit": {
             "locked": "4.12"
         },
@@ -107,12 +101,6 @@
             "transitive": [
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.safe-logging:preconditions"
-            ]
-        },
-        "javax.ws.rs:javax.ws.rs-api": {
-            "locked": "2.0.1",
-            "transitive": [
-                "com.palantir.conjure.java.api:errors"
             ]
         },
         "junit:junit": {

--- a/versions.props
+++ b/versions.props
@@ -2,7 +2,6 @@ com.fasterxml.jackson.*:jackson-* = 2.9.5
 com.google.code.findbugs:jsr305 = 3.0.1
 com.palantir.safe-logging:* = 1.5.0
 com.palantir.tokens:auth-tokens = 3.0.0
-javax.ws.rs:javax.ws.rs-api = 2.0.1
 junit:junit = 4.12
 org.apache.commons:commons-lang3 = 3.6
 org.assertj:assertj-core = 3.6.1


### PR DESCRIPTION
Nothing in this module uses jaxrs.