### PR TITLE
Add JSON annotations to ErrorType

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
@@ -16,6 +16,9 @@
 
 package com.palantir.conjure.java.api.errors;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.immutables.value.Value;
@@ -28,6 +31,9 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutablesStyle
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonSerialize(as = ImmutableErrorType.class)
+@JsonDeserialize(as = ImmutableErrorType.class)
 public abstract class ErrorType {
 
     private static final String UPPER_CAMEL_CASE = "(([A-Z][a-z0-9]+)+)";

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -33,11 +33,11 @@ import org.immutables.value.Value;
  * the (specific sub-) type of error, an optional set of named parameters detailing the error condition. Intended to
  * transport errors through RPC channels such as HTTP responses.
  */
-@JsonDeserialize(builder = SerializableError.Builder.class)
-@JsonSerialize(as = ImmutableSerializableError.class)
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@ImmutablesStyle
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonSerialize(as = ImmutableSerializableError.class)
+@JsonDeserialize(builder = SerializableError.Builder.class)
 public abstract class SerializableError implements Serializable {
 
     /**


### PR DESCRIPTION
`ErrorType` is a safe-loggable arg of a `ServiceException`. Our internal logging library logs arg values using an object mapper. However `ErrorType` does not have JSON property annotations and consequently always gets serialized as "{}", which is not very helpful.

EDIT: Would prefer to merge https://github.com/palantir/conjure-java-runtime/pull/827 instead.
