### PR TITLE
Log error name instead of error type

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 
 /** A {@link ServiceException} thrown in server-side code to indicate server-side {@link ErrorType error states}. */
 public final class ServiceException extends RuntimeException implements SafeLoggable {
-    public static final String ERROR_TYPE_ARG_NAME = "errorType";
+    public static final String ERROR_NAME_ARG_NAME = "errorName";
 
     private final ErrorType errorType;
     private final List<Arg<?>> args;  // unmodifiable
@@ -84,11 +84,11 @@ public final class ServiceException extends RuntimeException implements SafeLogg
     }
 
     /**
-     * Get Args of this service exception excluding injected/generated Args like errorType.
+     * Get Args of this service exception excluding injected/generated Args like errorName.
      * @return parameters passed to this ServiceException at construction time
      */
     public List<Arg<?>> getParameters() {
-        // errorType is always the first argument, so just slice it out
+        // errorName is always the first argument, so just slice it out
         return args.subList(1, args.size());
     }
 
@@ -122,7 +122,7 @@ public final class ServiceException extends RuntimeException implements SafeLogg
 
     private static List<Arg<?>> collectArgs(ErrorType errorType, Arg<?>... args) {
         List<Arg<?>> argList = new ArrayList<>(args.length + 1);
-        argList.add(SafeArg.of(ERROR_TYPE_ARG_NAME, errorType));
+        argList.add(SafeArg.of(ERROR_NAME_ARG_NAME, errorType.name()));
         Collections.addAll(argList, args);
         return Collections.unmodifiableList(argList);
     }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
@@ -28,7 +28,8 @@ import org.junit.Test;
 
 public final class ServiceExceptionTest {
 
-    private static final ErrorType ERROR = ErrorType.create(ErrorType.Code.CUSTOM_CLIENT, "Namespace:MyDesc");
+    private static final String ERROR_NAME = "Namespace:MyDesc";
+    private static final ErrorType ERROR = ErrorType.create(ErrorType.Code.CUSTOM_CLIENT, ERROR_NAME);
     private static final String EXPECTED_ERROR_MSG = "ServiceException: CUSTOM_CLIENT (Namespace:MyDesc)";
 
     @Test
@@ -43,7 +44,7 @@ public final class ServiceExceptionTest {
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo}");
 
         List<Arg<?>> expectedArgs = ImmutableList.<Arg<?>>builder()
-                .add(SafeArg.of(ServiceException.ERROR_TYPE_ARG_NAME, ERROR))
+                .add(SafeArg.of(ServiceException.ERROR_NAME_ARG_NAME, ERROR_NAME))
                 .add(args)
                 .build();
 
@@ -53,16 +54,16 @@ public final class ServiceExceptionTest {
     @Test
     public void testExceptionMessageWithNameCollisionWithInjectedArgs() {
         Arg<?>[] args = {
-                SafeArg.of(ServiceException.ERROR_TYPE_ARG_NAME, "foo"),
+                SafeArg.of(ServiceException.ERROR_NAME_ARG_NAME, "foo"),
                 UnsafeArg.of("arg2", 2),
                 UnsafeArg.of("arg3", null)};
         ServiceException ex = new ServiceException(ERROR, args);
 
         assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
-        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {errorType=foo}");
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {errorName=foo}");
 
         List<Arg<?>> expectedArgs = ImmutableList.<Arg<?>>builder()
-                .add(SafeArg.of(ServiceException.ERROR_TYPE_ARG_NAME, ERROR))
+                .add(SafeArg.of(ServiceException.ERROR_NAME_ARG_NAME, ERROR_NAME))
                 .add(args)
                 .build();
 


### PR DESCRIPTION
Follow up to #92 

`ErrorType` is a value type with multiple fields. Thus it is not an ideal arg value because it will be rendered as a JSON object, making it cumbersome to index, filter, read, etc.

Instead we should use the error name, which is simply a string. The error name is sufficient to fully determine the additional `ErrorType` information (each error name almost certainly has a single possible value for `code` and `httpCode`).