### PR TITLE
Latest baseline

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -48,13 +48,13 @@
         <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
     </module>
     <module name="SuppressWarningsFilter"/> <!-- baseline-gradle: README.md -->
-    <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->
-    <module name="SuppressionCommentFilter">
-        <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
-        <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
-        <property name="checkFormat" value="$1"/>
-    </module>
     <module name="TreeWalker">
+        <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
         <module name="AbbreviationAsWordInName"> <!-- Java Style Guide: Camel case : defined -->
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="1"/>
@@ -105,7 +105,6 @@
         <module name="EmptyStatement"/> <!-- Java Style Guide: One statement per line -->
         <module name="EqualsHashCode"/>
         <module name="FallThrough"/> <!-- Java Style Guide: Fall-through: commented -->
-        <module name="FileContentsHolder"/> <!-- Required for SuppressionCommentFilter -->
         <module name="FinalClass"/> <!-- Java Coding Guidelines: Private constructors -->
         <module name="GenericWhitespace"> <!-- Java Style Guide: Horizontal whitespace -->
             <message key="ws.followed" value="GenericWhitespace ''{0}'' is followed by whitespace."/>
@@ -124,11 +123,17 @@
             <message key="import.illegal" value="Use JUnit 4-style (org.junit.*) test classes and assertions instead of JUnit 3 (junit.framework.*)."/>
         </module>
         <module name="IllegalImport"> <!-- Java Coding Guidelines: Import the canonical package -->
-            <property name="illegalPkgs" value="org.elasticsearch.common.base, jersey.repackaged.com.google.common, com.google.api.client.repackaged, org.apache.hadoop.thirdparty.guava, com.clearspring.analytics.util, org.spark_project.guava"/>
+            <property name="illegalPkgs" value="org.elasticsearch.common.base, com.clearspring.analytics.util, org.spark_project.guava"/>
+            <message key="import.illegal" value="Must not import repackaged classes."/>
+        </module>
+        <module name="IllegalImport"> <!-- Java Coding Guidelines: Import the canonical package -->
+            <property name="illegalPkgs" value=".*\.(repackaged|shaded|thirdparty)"/>
+            <property name="regexp" value="true" />
             <message key="import.illegal" value="Must not import repackaged classes."/>
         </module>
         <module name="IllegalImport">
-            <property name="illegalPkgs" value="^org\.gradle\..*internal"/>
+            <property name="illegalPkgs" value="^org\.gradle\.(internal|.*\.internal)"/>
+            <property name="regexp" value="true" />
             <message key="import.illegal" value="Do not rely on gradle internal classes as these may change in minor releases - use org.gradle.api versions instead."/>
         </module>
         <module name="IllegalImport">
@@ -144,8 +149,13 @@
             <message key="import.illegal" value="math is deprecated, use math3 instead."/>
         </module>
         <module name="IllegalImport">
+            <property name="id" value="BanLoggingImplementations"/>
             <property name="illegalPkgs" value="org.apache.log4j, org.apache.logging.log4j, java.util.logging, ch.qos.logback"/>
             <message key="import.illegal" value="Use SLF4J instead of a logging framework directly."/>
+        </module>
+        <module name="IllegalImport">
+            <property name="illegalClasses" value="com.google.common.base.Optional, com.google.common.base.Supplier"/>
+            <message key="import.illegal" value="Use the Java8 version of Guava objects."/>
         </module>
         <module name="IllegalInstantiation"> <!-- Java Coding Guidelines: Never instantiate primitive types -->
             <property name="classes" value="java.lang.Boolean"/>
@@ -165,9 +175,15 @@
         <module name="IllegalType"> <!-- Java Coding Guide: Limit coupling on concrete classes -->
             <property name="illegalClassNames" value="java.util.ArrayList, java.util.HashSet, java.util.HashMap, java.util.LinkedList, java.util.LinkedHashMap, java.util.LinkedHashSet, java.util.TreeSet, java.util.TreeMap, com.google.common.collect.ArrayListMultimap, com.google.common.collect.ForwardingListMultimap, com.google.common.collect.ForwardingMultimap, com.google.common.collect.ForwardingSetMultimap, com.google.common.collect.ForwardingSortedSetMultimap, com.google.common.collect.HashMultimap, com.google.common.collect.LinkedHashMultimap, com.google.common.collect.LinkedListMultimap, com.google.common.collect.TreeMultimap"/>
         </module>
+        <module name="IllegalType">
+            <property name="id" value="BanGuavaCaches"/>
+            <property name="illegalClassNames" value="com.google.common.cache.CacheBuilder, com.google.common.cache.Cache, com.google.common.cache.LoadingCache"/>
+            <message key="illegal.type" value="Do not use Guava caches, they are outperformed by and harder to use than Caffeine caches"/>
+        </module>
         <module name="ImportOrder"> <!-- Java Style Guide: Ordering and spacing -->
             <property name="groups" value="/.*/"/>
             <property name="option" value="top"/>
+            <property name="separated" value="true"/>
             <property name="sortStaticImportsAlphabetically" value="true"/>
         </module>
         <module name="Indentation"> <!-- Java Style Guide: Block indentation: +4 spaces -->
@@ -175,9 +191,7 @@
             <property name="lineWrappingIndentation" value="8"/>
         </module>
         <module name="InnerAssignment"/> <!-- Java Coding Guidelines: Inner assignments: Not used -->
-        <module name="LeftCurly"> <!-- Java Style Guide: Nonempty blocks: K & R style -->
-            <property name="maxLineLength" value="120"/>
-        </module>
+        <module name="LeftCurly"/> <!-- Java Style Guide: Nonempty blocks: K & R style -->
         <module name="LineLength"> <!-- Java Style Guide: No line-wrapping -->
             <property name="max" value="120"/>
             <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
@@ -265,6 +279,11 @@
             <property name="format" value="CoreMatchers\.equalTo"/>
             <property name="message" value="Use Assert.assertEquals()."/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="BanJacksonFindAndRegisterModulesMethod"/>
+            <property name="format" value="findAndRegisterModules"/>
+            <property name="message" value="Use ObjectMapper#registerModule(&lt;yourModule&gt;) explicitly. ObjectMapper#findAndRegisterModules() is dangerous because it will change behaviour depending on which modules are on your classpath (including transitive dependencies)."/>
+        </module>
         <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Use appropriate assertion methods -->
             <property name="format" value="CoreMatchers\.notNull"/>
             <property name="message" value="Use better assertion method(s): Assert.assertEquals(), assertNull(), assertSame(), etc."/>
@@ -333,7 +352,7 @@
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="\/\/TODO|\/\/ TODO(?!\([^()\s]+\): )"/>
-            <property name="message" value="TODO format: // TODO(flastname): explanation"/>
+            <property name="message" value="TODO format: // TODO(#issue): explanation"/>
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>
@@ -392,7 +411,9 @@
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="CyclomaticComplexity"/> <!-- Java Coding Guidelines: Reduce Cyclomatic Complexity -->
-        <module name="DesignForExtension"/> <!-- Java Coding Guidelines: Design for extension -->
+        <module name="DesignForExtension"> <!-- Java Coding Guidelines: Design for extension -->
+            <property name="ignoredAnnotations" value="Test, Before, BeforeEach, After, AfterEach, BeforeClass, BeforeAll, AfterClass, AfterAll"/>
+        </module>
         <module name="JavadocMethod"> <!-- Java Style Guide: Where Javadoc is used -->
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>

--- a/build.gradle
+++ b/build.gradle
@@ -1,64 +1,36 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url  "http://palantir.bintray.com/releases" }
+        maven { url  "https://palantir.bintray.com/releases" }
     }
 
     dependencies {
-        classpath 'gradle.plugin.com.palantir:gradle-circle-style:1.1.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.netflix.nebula:gradle-dependency-lock-plugin:5.0.6'
-        classpath 'com.netflix.nebula:nebula-dependency-recommender:6.0.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.4'
         classpath 'com.palantir.baseline:gradle-baseline-java:0.34.0'
-        classpath 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin:0.3.0'
     }
 }
 
 plugins {
     id 'com.palantir.git-version' version '0.11.0'
-    id 'org.inferred.processors' version '1.2.15'
+    id 'org.inferred.processors' version '1.3.0'
 }
 
-apply plugin: 'com.palantir.baseline-config' // provides baselineUpdateConfig task
-apply plugin: 'com.palantir.baseline-idea'
-apply plugin: 'com.palantir.circle.style'
-
-repositories {
-    maven { url "http://palantir.bintray.com/releases" }
-}
-
-dependencies {
-    baseline 'com.palantir.baseline:gradle-baseline-java-config:0.34.0@zip'
-}
+apply plugin: 'com.palantir.baseline'
 
 allprojects {
+    repositories {
+        maven { url  "https://palantir.bintray.com/releases" }
+        jcenter()
+    }
+
     version gitVersion()
     group 'com.palantir.conjure.java.api'
-
-    apply plugin: 'com.palantir.configuration-resolver'
-    apply plugin: 'nebula.dependency-recommender'
-    dependencyRecommendations {
-        strategy OverrideTransitives
-        propertiesFile file: project.rootProject.file('versions.props')
-    }
 }
 
 subprojects {
     apply plugin: 'java'
-    apply plugin: 'com.palantir.baseline-checkstyle'
-    apply plugin: 'com.palantir.baseline-eclipse'
-    apply plugin: 'com.palantir.baseline-error-prone'
-    apply plugin: 'com.palantir.baseline-idea'
-
-    repositories {
-        jcenter()
-        maven { url  "http://palantir.bintray.com/releases" }
-    }
-    configurations.errorprone.resolutionStrategy.force 'com.google.guava:guava:21.0'
-    tasks.withType(JavaCompile) {
-        options.compilerArgs += ['-XepDisableWarningsInGeneratedCode']
-    }
 
     sourceCompatibility = 1.8
 
@@ -84,10 +56,6 @@ subprojects {
     build.dependsOn(verifyDependencyLocksAreCurrent)
 
     tasks.check.dependsOn(javadoc)
-
-    if (System.env.CIRCLE_TEST_REPORTS) {
-        test.reports.junitXml.destination = new File(System.env.CIRCLE_TEST_REPORTS, it.getName())
-    }
 
     test {
         minHeapSize = "512m"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath 'com.netflix.nebula:gradle-dependency-lock-plugin:5.0.6'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:6.0.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.4'
-        classpath 'com.palantir.baseline:gradle-baseline-java:0.26.1'
+        classpath 'com.palantir.baseline:gradle-baseline-java:0.34.0'
         classpath 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin:0.3.0'
     }
 }
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    baseline 'com.palantir.baseline:gradle-baseline-java-config:0.26.1@zip'
+    baseline 'com.palantir.baseline:gradle-baseline-java-config:0.34.0@zip'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url  "https://palantir.bintray.com/releases" }
+        maven { url  'https://palantir.bintray.com/releases' }
     }
 
     dependencies {
@@ -21,12 +21,18 @@ apply plugin: 'com.palantir.baseline'
 
 allprojects {
     repositories {
-        maven { url  "https://palantir.bintray.com/releases" }
+        maven { url  'https://palantir.bintray.com/releases' }
         jcenter()
     }
 
-    version gitVersion()
     group 'com.palantir.conjure.java.api'
+    version gitVersion()
+
+    configurations.all {
+        resolutionStrategy {
+            failOnVersionConflict()
+        }
+    }
 }
 
 subprojects {

--- a/errors/build.gradle
+++ b/errors/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
     compile "com.google.code.findbugs:jsr305"
     compile "com.palantir.safe-logging:safe-logging"
-    implementation 'com.google.guava:guava'
     implementation "com.palantir.safe-logging:preconditions"
 
     testCompile project(":extras:jackson-support")

--- a/errors/build.gradle
+++ b/errors/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
     compile "com.google.code.findbugs:jsr305"
     compile "com.palantir.safe-logging:safe-logging"
+    implementation 'com.google.guava:guava'
     implementation "com.palantir.safe-logging:preconditions"
 
     testCompile project(":extras:jackson-support")

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -36,7 +36,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = SerializableError.Builder.class)
 @JsonSerialize(as = ImmutableSerializableError.class)
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, jdkOnly = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class SerializableError implements Serializable {
 

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -82,6 +82,7 @@ public abstract class SerializableError implements Serializable {
     public abstract Map<String, String> parameters();
 
     /**
+     * Returns the deprecated "exceptionClass" field returned by remoting2 servers.
      * @deprecated Used by the serialization-mechanism for back-compat only. Do not use.
      */
     @Deprecated
@@ -91,6 +92,7 @@ public abstract class SerializableError implements Serializable {
     abstract Optional<String> getExceptionClass();
 
     /**
+     * Returns the deprecated "message" field returned by remoting2 servers.
      * @deprecated Used by the serialization-mechanism for back-compat only. Do not use.
      */
     @Deprecated

--- a/errors/versions.lock
+++ b/errors/versions.lock
@@ -1,60 +1,177 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
+        },
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1"
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.3",
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava",
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "23.5-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.34.0",
+            "requested": "0.34.0"
+        },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.5.1"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "1.5.1",
             "transitive": [
                 "com.palantir.safe-logging:preconditions"
             ]
         },
-        "com.palantir.safe-logging:preconditions": {
-            "locked": "1.5.0"
-        },
-        "com.palantir.safe-logging:safe-logging": {
-            "locked": "1.5.0",
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.0",
             "transitive": [
-                "com.palantir.safe-logging:preconditions"
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.0",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.immutables:value": {
+            "locked": "2.7.1"
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1"
+            "locked": "3.0.2"
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "1.5.0"
+            "locked": "1.5.1"
         }
     }
 }

--- a/errors/versions.lock
+++ b/errors/versions.lock
@@ -82,7 +82,7 @@
             ]
         },
         "com.google.guava:guava": {
-            "locked": "23.5-jre",
+            "locked": "23.6-jre",
             "transitive": [
                 "com.google.auto:auto-common",
                 "com.google.errorprone:error_prone_annotation",
@@ -114,10 +114,15 @@
                 "com.palantir.safe-logging:preconditions"
             ]
         },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
         "org.checkerframework:checker-qual": {
             "locked": "2.5.0",
             "transitive": [
-                "com.google.guava:guava",
                 "org.checkerframework:dataflow",
                 "org.checkerframework:javacutil"
             ]

--- a/extras/jackson-support/versions.lock
+++ b/extras/jackson-support/versions.lock
@@ -42,10 +42,40 @@
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
             "locked": "2.9.7"
         },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
         "com.google.guava:guava": {
-            "locked": "18.0",
+            "locked": "23.6-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
             ]
         }
     },
@@ -92,10 +122,40 @@
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
             "locked": "2.9.7"
         },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
         "com.google.guava:guava": {
-            "locked": "18.0",
+            "locked": "23.6-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
             ]
         }
     }

--- a/extras/jackson-support/versions.lock
+++ b/extras/jackson-support/versions.lock
@@ -1,14 +1,14 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
@@ -19,7 +19,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -28,19 +28,19 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.google.guava:guava": {
             "locked": "18.0",
@@ -51,14 +51,14 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
@@ -69,7 +69,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -78,19 +78,19 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         },
         "com.google.guava:guava": {
             "locked": "18.0",

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.net.URL;
 import org.junit.Test;
 
+@SuppressWarnings("CheckReturnValue") // .build() is used to throw validation exceptions
 public final class ProxyConfigurationTests {
     private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory()).registerModule(new Jdk8Module());
 

--- a/service-config/versions.lock
+++ b/service-config/versions.lock
@@ -94,7 +94,7 @@
             ]
         },
         "com.google.guava:guava": {
-            "locked": "23.5-jre",
+            "locked": "23.6-jre",
             "transitive": [
                 "com.google.auto:auto-common",
                 "com.google.errorprone:error_prone_annotation",
@@ -132,10 +132,15 @@
         "com.palantir.tokens:auth-tokens": {
             "locked": "3.3.0"
         },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
         "org.checkerframework:checker-qual": {
             "locked": "2.5.0",
             "transitive": [
-                "com.google.guava:guava",
                 "org.checkerframework:dataflow",
                 "org.checkerframework:javacutil"
             ]
@@ -204,7 +209,7 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.3",
+            "locked": "2.3.1",
             "transitive": [
                 "com.palantir.safe-logging:preconditions"
             ]

--- a/service-config/versions.lock
+++ b/service-config/versions.lock
@@ -1,20 +1,20 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.palantir.conjure.java.api:ssl-config",
@@ -22,31 +22,151 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"
             ]
         },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.3",
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
             "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava",
                 "com.palantir.safe-logging:preconditions"
             ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "23.5-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.34.0",
+            "requested": "0.34.0"
         },
         "com.palantir.conjure.java.api:ssl-config": {
             "project": true
         },
         "com.palantir.safe-logging:preconditions": {
-            "locked": "1.5.0"
+            "locked": "1.5.1"
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "1.5.0",
+            "locked": "1.5.1",
             "transitive": [
                 "com.palantir.safe-logging:preconditions"
             ]
         },
         "com.palantir.tokens:auth-tokens": {
-            "locked": "3.0.0"
+            "locked": "3.3.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.0",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.0",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.immutables:value": {
+            "locked": "2.7.1"
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
@@ -57,20 +177,20 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.palantir.conjure.java.api:ssl-config",
@@ -78,7 +198,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"
             ]
@@ -93,16 +213,16 @@
             "project": true
         },
         "com.palantir.safe-logging:preconditions": {
-            "locked": "1.5.0"
+            "locked": "1.5.1"
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "1.5.0",
+            "locked": "1.5.1",
             "transitive": [
                 "com.palantir.safe-logging:preconditions"
             ]
         },
         "com.palantir.tokens:auth-tokens": {
-            "locked": "3.0.0"
+            "locked": "3.3.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",

--- a/ssl-config/versions.lock
+++ b/ssl-config/versions.lock
@@ -1,36 +1,161 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
+        },
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "23.5-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.34.0",
+            "requested": "0.34.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.0",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.0",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.immutables:value": {
+            "locked": "2.7.1"
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
         }
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5"
+            "locked": "2.9.7"
         }
     }
 }

--- a/ssl-config/versions.lock
+++ b/ssl-config/versions.lock
@@ -81,7 +81,7 @@
             ]
         },
         "com.google.guava:guava": {
-            "locked": "23.5-jre",
+            "locked": "23.6-jre",
             "transitive": [
                 "com.google.auto:auto-common",
                 "com.google.errorprone:error_prone_annotation",
@@ -104,10 +104,15 @@
             "locked": "0.34.0",
             "requested": "0.34.0"
         },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
         "org.checkerframework:checker-qual": {
             "locked": "2.5.0",
             "transitive": [
-                "com.google.guava:guava",
                 "org.checkerframework:dataflow",
                 "org.checkerframework:javacutil"
             ]

--- a/test-utils/versions.lock
+++ b/test-utils/versions.lock
@@ -1,34 +1,118 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.palantir.conjure.java.api:errors"
             ]
         },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
             "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava",
                 "com.palantir.conjure.java.api:errors"
             ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "23.5-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.34.0",
+            "requested": "0.34.0"
         },
         "com.palantir.conjure.java.api:errors": {
             "project": true
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "1.5.0",
+            "locked": "1.5.1",
             "transitive": [
                 "com.palantir.conjure.java.api:errors"
             ]
@@ -36,47 +120,91 @@
         "junit:junit": {
             "locked": "4.12"
         },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.8.21",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.8.21",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
         "org.assertj:assertj-core": {
             "locked": "3.6.1"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.0",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.0",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
-                "junit:junit",
-                "org.mockito:mockito-core"
+                "junit:junit"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "1.10.19"
+            "locked": "2.22.0"
         },
         "org.objenesis:objenesis": {
-            "locked": "2.1",
+            "locked": "2.6",
             "transitive": [
                 "org.mockito:mockito-core"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.5",
+            "locked": "2.9.7",
             "transitive": [
                 "com.palantir.conjure.java.api:errors"
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
+            "locked": "3.0.2",
             "transitive": [
                 "com.palantir.conjure.java.api:errors"
             ]
@@ -91,13 +219,13 @@
             "project": true
         },
         "com.palantir.safe-logging:preconditions": {
-            "locked": "1.5.0",
+            "locked": "1.5.1",
             "transitive": [
                 "com.palantir.conjure.java.api:errors"
             ]
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "1.5.0",
+            "locked": "1.5.1",
             "transitive": [
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.safe-logging:preconditions"
@@ -106,21 +234,32 @@
         "junit:junit": {
             "locked": "4.12"
         },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.8.21",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.8.21",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
         "org.assertj:assertj-core": {
             "locked": "3.6.1"
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
-                "junit:junit",
-                "org.mockito:mockito-core"
+                "junit:junit"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "1.10.19"
+            "locked": "2.22.0"
         },
         "org.objenesis:objenesis": {
-            "locked": "2.1",
+            "locked": "2.6",
             "transitive": [
                 "org.mockito:mockito-core"
             ]

--- a/test-utils/versions.lock
+++ b/test-utils/versions.lock
@@ -211,27 +211,13 @@
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.2",
             "transitive": [
-                "com.google.guava:guava",
                 "com.palantir.conjure.java.api:errors"
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.3.1",
             "transitive": [
-                "com.google.guava:guava",
                 "com.palantir.safe-logging:preconditions"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "23.6-jre",
-            "transitive": [
-                "com.palantir.conjure.java.api:errors"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "com.palantir.conjure.java.api:errors": {
@@ -267,18 +253,6 @@
         },
         "org.assertj:assertj-core": {
             "locked": "3.6.1"
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",

--- a/test-utils/versions.lock
+++ b/test-utils/versions.lock
@@ -85,7 +85,7 @@
             ]
         },
         "com.google.guava:guava": {
-            "locked": "23.5-jre",
+            "locked": "23.6-jre",
             "transitive": [
                 "com.google.auto:auto-common",
                 "com.google.errorprone:error_prone_annotation",
@@ -135,10 +135,15 @@
         "org.assertj:assertj-core": {
             "locked": "3.6.1"
         },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
         "org.checkerframework:checker-qual": {
             "locked": "2.5.0",
             "transitive": [
-                "com.google.guava:guava",
                 "org.checkerframework:dataflow",
                 "org.checkerframework:javacutil"
             ]
@@ -206,13 +211,27 @@
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.2",
             "transitive": [
+                "com.google.guava:guava",
                 "com.palantir.conjure.java.api:errors"
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.3",
+            "locked": "2.3.1",
             "transitive": [
+                "com.google.guava:guava",
                 "com.palantir.safe-logging:preconditions"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "23.6-jre",
+            "transitive": [
+                "com.palantir.conjure.java.api:errors"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
             ]
         },
         "com.palantir.conjure.java.api:errors": {
@@ -248,6 +267,18 @@
         },
         "org.assertj:assertj-core": {
             "locked": "3.6.1"
+        },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",

--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,6 @@
 com.fasterxml.jackson.*:jackson-* = 2.9.7
 com.google.code.findbugs:jsr305 = 3.0.2
+com.google.guava:guava = 23.6-jre
 com.palantir.safe-logging:* = 1.5.1
 com.palantir.tokens:auth-tokens = 3.3.0
 junit:junit = 4.12
@@ -7,3 +8,6 @@ org.apache.commons:commons-lang3 = 3.8.1
 org.assertj:assertj-core = 3.6.1
 org.immutables:value = 2.7.1
 org.mockito:mockito-core = 2.22.0
+
+# conflict resolution
+com.google.errorprone:error_prone_annotations = 2.3.1

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 com.fasterxml.jackson.*:jackson-* = 2.9.7
 com.google.code.findbugs:jsr305 = 3.0.2
-com.palantir.safe-logging:* = 1.5.0
+com.palantir.safe-logging:* = 1.5.1
 com.palantir.tokens:auth-tokens = 3.3.0
 junit:junit = 4.12
 org.apache.commons:commons-lang3 = 3.8.1


### PR DESCRIPTION
Note, this also bumps guava from 18.0 -> 23.6-jre and enables `failOnVersionConflict()`