### PR TITLE
[improvement] Add SYSTEM proxy configuration

### DIFF
--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import java.net.ProxySelector;
 import java.util.Optional;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
@@ -35,6 +36,11 @@ public abstract class ProxyConfiguration {
     public static final ProxyConfiguration DIRECT = new ProxyConfiguration.Builder().type(Type.DIRECT).build();
 
     public enum Type {
+
+        /**
+         * Use the JVM's default proxy selector {@link ProxySelector#getDefault()}.
+         */
+        SYSTEM,
 
         /** Use a direct connection. This option will bypass any JVM-level configured proxy settings. */
         DIRECT,
@@ -88,9 +94,10 @@ public abstract class ProxyConfiguration {
                 Preconditions.checkArgument(host.hasPort(),
                         "Given hostname does not contain a port number", SafeArg.of("hostname", host));
                 break;
+            case SYSTEM:
             case DIRECT:
                 Preconditions.checkArgument(!hostAndPort().isPresent() && !credentials().isPresent(),
-                        "Neither credential nor host-and-port may be configured for DIRECT proxies");
+                        "Neither credential nor host-and-port may be configured for DIRECT or SYSTEM proxies");
                 break;
             default:
                 throw new IllegalStateException("Unrecognized case; this is a library bug");

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
@@ -69,13 +69,23 @@ public final class ProxyConfigurationTests {
     }
 
     @Test
-    public void testNonHttpProxyWithHostAndPort() {
+    public void testDirectProxyWithHostAndPort() {
         assertThatThrownBy(() -> new ProxyConfiguration.Builder()
                 .hostAndPort("squid:3128")
                 .type(ProxyConfiguration.Type.DIRECT)
                 .build())
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Neither credential nor host-and-port may be configured for DIRECT proxies");
+                .hasMessage("Neither credential nor host-and-port may be configured for DIRECT or SYSTEM proxies");
+    }
+
+    @Test
+    public void testSystemProxyWithHostAndPort() {
+        assertThatThrownBy(() -> new ProxyConfiguration.Builder()
+                .hostAndPort("squid:3128")
+                .type(ProxyConfiguration.Type.SYSTEM)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Neither credential nor host-and-port may be configured for DIRECT or SYSTEM proxies");
     }
 
     @Test

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
@@ -95,7 +95,7 @@ public final class ProxyConfigurationTests {
                 .type(ProxyConfiguration.Type.DIRECT)
                 .build())
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Neither credential nor host-and-port may be configured for DIRECT proxies");
+                .hasMessage("Neither credential nor host-and-port may be configured for DIRECT or SYSTEM proxies");
         assertThatThrownBy(() -> ProxyConfiguration.builder()
                 .type(ProxyConfiguration.Type.MESH)
                 .credentials(BasicCredentials.of("foo", "bar"))


### PR DESCRIPTION
There is currently no way to defer to the JVM's `ProxySelector#getDefault` selector.