### PR TITLE
Update docs. All args are propagated, not only safe ones

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
@@ -35,7 +35,7 @@ public final class ServiceException extends RuntimeException implements SafeLogg
     private final String noArgsMessage;
 
     /**
-     * Creates a new exception for the given error. All {@link com.palantir.logsafe.SafeArg safe} parameters are
+     * Creates a new exception for the given error. All {@link com.palantir.logsafe.Arg parameters} are
      * propagated to clients; they are serialized via {@link Object#toString}.
      */
     public ServiceException(ErrorType errorType, Arg<?>... parameters) {


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Docs were misleading and said only safe args from a ServiceException were propagated

## After this PR
Docs are accurate and say all args are propagated