### PR TITLE
[improvement] Make RemoteException implement SafeLoggable

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -16,7 +16,9 @@
 
 package com.palantir.conjure.java.api.errors;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.List;
@@ -50,14 +52,19 @@ public final class RemoteException extends RuntimeException implements SafeLogga
 
         this.error = error;
         this.status = status;
-        this.args = error.parameters().entrySet().stream()
-                .map(entry -> UnsafeArg.of(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toList());
+        this.args = ImmutableList.<Arg<?>>builder()
+                .add(SafeArg.of("errorName", error.errorName()))
+                .add(SafeArg.of("errorCode", error.errorCode()))
+                .add(SafeArg.of("errorInstanceId", error.errorInstanceId()))
+                .addAll(error.parameters().entrySet().stream()
+                        .map(entry -> UnsafeArg.of(entry.getKey(), entry.getValue()))
+                        .collect(Collectors.toList()))
+                .build();
     }
 
     @Override
     public String getLogMessage() {
-        return getMessage();
+        return "RemoteException";
     }
 
     @Override

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -16,14 +16,21 @@
 
 package com.palantir.conjure.java.api.errors;
 
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.UnsafeArg;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * An exception thrown by an RPC client to indicate remote/server-side failure.
  */
-public final class RemoteException extends RuntimeException {
+public final class RemoteException extends RuntimeException implements SafeLoggable {
     private static final long serialVersionUID = 1L;
 
     private final SerializableError error;
     private final int status;
+    private final List<Arg<?>> args;
 
     /** Returns the error thrown by a remote process which caused an RPC call to fail. */
     public SerializableError getError() {
@@ -43,5 +50,18 @@ public final class RemoteException extends RuntimeException {
 
         this.error = error;
         this.status = status;
+        this.args = error.parameters().entrySet().stream()
+                .map(entry -> UnsafeArg.of(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getLogMessage() {
+        return getMessage();
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return args;
     }
 }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
@@ -18,6 +18,8 @@ package com.palantir.conjure.java.api.errors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
@@ -62,5 +64,23 @@ public final class RemoteExceptionTest {
                 .build();
         assertThat(new RemoteException(error, 500).getMessage())
                 .isEqualTo("RemoteException: errorCode with instance ID errorId");
+    }
+
+    @Test
+    public void testSafeLogging() {
+        SerializableError error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .errorInstanceId("errorId")
+                .putParameters("parameter", "value")
+                .build();
+
+        assertThat(new RemoteException(error, 500).getLogMessage())
+                .isEqualTo("RemoteException");
+        assertThat(new RemoteException(error, 500).getArgs()).containsExactly(
+                SafeArg.of("errorName", "errorName"),
+                SafeArg.of("errorCode", "errorCode"),
+                SafeArg.of("errorInstanceId", "errorId"),
+                UnsafeArg.of("parameter", "value"));
     }
 }


### PR DESCRIPTION
Enable stacktraces containing remote exceptions to surface the error code and instanceId.

## Before this PR
Stack traces containing remote exceptions don't surface useful information like the instanceId and errorCode. 

## After this PR
Stack trace contains richer information by safe logging the exception message for remote exceptions.