### PR TITLE
Add a flag for retrying on timeout

### DIFF
--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
@@ -52,6 +52,15 @@ public interface ServiceConfiguration {
 
     Optional<ProxyConfiguration> proxy();
 
+    /**
+     * Enables old behavior of retrying on timeout.
+     *
+     * This is a dangerous flag to enable! Retrying timed out requests can easily lead to retry storms.
+     *
+     * See GitHub issue for more details: https://github.com/palantir/conjure-java-runtime/issues/1084
+     */
+    Optional<Boolean> enableRetryOnTimeout();
+
     static ImmutableServiceConfiguration.Builder builder() {
         return new Builder();
     }

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
@@ -59,7 +59,7 @@ public interface ServiceConfiguration {
      *
      * See GitHub issue for more details: https://github.com/palantir/conjure-java-runtime/issues/1084
      */
-    Optional<Boolean> enableRetryOnTimeout();
+    Optional<Boolean> retryOnTimeout();
 
     static ImmutableServiceConfiguration.Builder builder() {
         return new Builder();


### PR DESCRIPTION
Define a feature flag escape hatch for retrying on timeout. This is the current behavior, but I intend to disable retrying on timeouts by default.

See https://github.com/palantir/conjure-java-runtime/pull/1085 for more context.