### PR TITLE
Allow qos config per service

### DIFF
--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/NodeSelectionStrategy.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/NodeSelectionStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.config.service;
+
+public enum NodeSelectionStrategy {
+
+    /**
+     * Once a node is found that returns responses successfully, use that node until a failure is received, then select
+     * a new node. This strategy allows for the implementation to repin to a new node at any point in time. If this
+     * behavior is not desirable, you can use {@link #PIN_UNTIL_ERROR_WITHOUT_RESHUFFLE}.
+     */
+    PIN_UNTIL_ERROR,
+
+    /**
+     * For each new request, select the "next" node (in some undefined order).
+     */
+    ROUND_ROBIN,
+
+    /**
+     * Similar to {@link #PIN_UNTIL_ERROR}, except will not shuffle the URLs throughout the lifetime of the client.
+     */
+    PIN_UNTIL_ERROR_WITHOUT_RESHUFFLE
+}

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/PartialServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/PartialServiceConfiguration.java
@@ -58,6 +58,19 @@ public interface PartialServiceConfiguration {
     Optional<Integer> maxNumRetries();
 
     /**
+     * Indicates how the target node is selected for a given request.
+     */
+    @JsonAlias("node-selection-strategy")
+    Optional<NodeSelectionStrategy> nodeSelectionStrategy();
+
+    /**
+     * The amount of time a URL marked as failed should be avoided for subsequent calls. If the
+     * {@link #nodeSelectionStrategy} is ROUND_ROBIN, this must be a positive period of time.
+     */
+    @JsonAlias("failed-url-cooldown")
+    Optional<HumanReadableDuration> failedUrlCooldown();
+
+    /**
      * The size of one backoff time slot for call retries. For example, an exponential backoff retry algorithm may
      * choose a backoff time in {@code [0, backoffSlotSize * 2^c]} for the c-th retry.
      */

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
@@ -44,6 +44,10 @@ public interface ServiceConfiguration {
 
     Optional<Integer> maxNumRetries();
 
+    Optional<NodeSelectionStrategy> nodeSelectionStrategy();
+
+    Optional<Duration> failedUrlCooldown();
+
     Optional<Duration> backoffSlotSize();
 
     Optional<Boolean> enableGcmCipherSuites();

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactory.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactory.java
@@ -83,6 +83,9 @@ public final class ServiceConfigurationFactory {
                 .maxNumRetries(partial.maxNumRetries())
                 .backoffSlotSize(orElse(partial.backoffSlotSize(), services.defaultBackoffSlotSize())
                         .map(t -> Duration.ofMillis(t.toMilliseconds())))
+                .failedUrlCooldown(orElse(partial.failedUrlCooldown(), services.defaultFailedUrlCooldown())
+                        .map(t -> Duration.ofMillis(t.toMilliseconds())))
+                .nodeSelectionStrategy(orElse(partial.nodeSelectionStrategy(), services.defaultNodeSelectionStrategy()))
                 .proxy(orElse(partial.proxyConfiguration(), services.defaultProxyConfiguration()))
                 .enableGcmCipherSuites(
                         orElse(partial.enableGcmCipherSuites(), services.defaultEnableGcmCipherSuites()))

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServicesConfigBlock.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServicesConfigBlock.java
@@ -85,6 +85,20 @@ public abstract class ServicesConfigBlock {
     public abstract Optional<HumanReadableDuration> defaultWriteTimeout();
 
     /**
+     * Default node selection strategy.
+     */
+    @JsonProperty("defaultNodeSelectionStrategy")
+    @JsonAlias("node-selection-strategy")
+    public abstract Optional<NodeSelectionStrategy> defaultNodeSelectionStrategy();
+
+    /**
+     * Default failed url cooldown.
+     */
+    @JsonProperty("defaultFailedUrlCooldown")
+    @JsonAlias("failed-url-cooldown")
+    public abstract Optional<HumanReadableDuration> defaultFailedUrlCooldown();
+
+    /**
      * Default global backoff slot size, see {@link PartialServiceConfiguration#backoffSlotSize()}.
      */
     @JsonProperty("backoffSlotSize")


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Cannot set QoS configurations in config per service.

## After this PR
Can set QoS configurations in config per service. We often need to cut releases to modify the node selection strategy and failedCoolDown period. This allows us to get out of P0s with a simple config change.

## Possible downsides?
Too configurable.