### PR TITLE
Make RemoteException SafeLoggable and add parameters to message

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -16,14 +16,35 @@
 
 package com.palantir.conjure.java.api.errors;
 
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.UnsafeArg;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
 /**
  * An exception thrown by an RPC client to indicate remote/server-side failure.
  */
-public final class RemoteException extends RuntimeException {
+public final class RemoteException extends RuntimeException implements SafeLoggable {
     private static final long serialVersionUID = 1L;
 
     private final SerializableError error;
     private final int status;
+
+    private final String noArgsMessage;
+    private final List<Arg<?>> args; // unmodifiable
+
+    public RemoteException(SerializableError error, int status) {
+        super(renderUnsafeMessage(error));
+
+        this.error = error;
+        this.status = status;
+        this.noArgsMessage = renderNoArgsMessage(error);
+        this.args = copyArgsToUnmodifiableList(error);
+    }
 
     /** Returns the error thrown by a remote process which caused an RPC call to fail. */
     public SerializableError getError() {
@@ -35,13 +56,54 @@ public final class RemoteException extends RuntimeException {
         return status;
     }
 
-    public RemoteException(SerializableError error, int status) {
-        super(error.errorCode().equals(error.errorName())
+    @Override
+    public String getLogMessage() {
+        return noArgsMessage;
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return args;
+    }
+
+    private static List<Arg<?>> copyArgsToUnmodifiableList(SerializableError error) {
+        Map<String, String> parameters = error.parameters();
+
+        List<Arg<?>> argsList = new ArrayList<>(parameters.size());
+        for (Entry<String, String> parameter : parameters.entrySet()) {
+            argsList.add(UnsafeArg.of(parameter.getKey(), parameter.getValue()));
+        }
+        return Collections.unmodifiableList(argsList);
+    }
+
+    private static String renderUnsafeMessage(SerializableError error) {
+        String message = renderNoArgsMessage(error);
+        Map<String, String> parameters = error.parameters();
+
+        if (parameters.size() == 0) {
+            return message;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(message).append(": {");
+        boolean first = true;
+        for (Entry<String, String> parameter : parameters.entrySet()) {
+            if (first) {
+                first = false;
+            } else {
+                builder.append(", ");
+            }
+            builder.append(parameter.getKey()).append("=").append(parameter.getValue());
+        }
+        builder.append("}");
+
+        return builder.toString();
+    }
+
+    private static String renderNoArgsMessage(SerializableError error) {
+        return error.errorCode().equals(error.errorName())
                 ? String.format("RemoteException: %s with instance ID %s", error.errorCode(), error.errorInstanceId())
                 : String.format("RemoteException: %s (%s) with instance ID %s",
-                        error.errorCode(), error.errorName(), error.errorInstanceId()));
-
-        this.error = error;
-        this.status = status;
+                        error.errorCode(), error.errorName(), error.errorInstanceId());
     }
 }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.api.errors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.logsafe.UnsafeArg;
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
@@ -46,21 +47,40 @@ public final class RemoteExceptionTest {
     }
 
     @Test
-    public void testSuperMessage() {
+    public void testExceptionMessage() {
         SerializableError error = new SerializableError.Builder()
                 .errorCode("errorCode")
                 .errorName("errorName")
                 .errorInstanceId("errorId")
+                .putParameters("parameter1", "foo")
+                .putParameters("parameter2", "bar")
                 .build();
-        assertThat(new RemoteException(error, 500).getMessage())
-                .isEqualTo("RemoteException: errorCode (errorName) with instance ID errorId");
+        RemoteException ex = new RemoteException(error, 500);
 
-        error = new SerializableError.Builder()
+        String expectedMessage = "RemoteException: errorCode (errorName) with instance ID errorId";
+        assertThat(ex.getMessage()).isEqualTo(expectedMessage + ": {parameter1=foo, parameter2=bar}");
+        assertThat(ex.getLogMessage()).isEqualTo(expectedMessage);
+        assertThat(ex.getArgs()).containsExactly(
+                UnsafeArg.of("parameter1", "foo"),
+                UnsafeArg.of("parameter2", "bar"));
+    }
+
+    @Test
+    public void testExceptionMessageWithIdenticalErrorName() {
+        SerializableError error = new SerializableError.Builder()
                 .errorCode("errorCode")
                 .errorName("errorCode")
                 .errorInstanceId("errorId")
+                .putParameters("parameter1", "foo")
+                .putParameters("parameter2", "bar")
                 .build();
-        assertThat(new RemoteException(error, 500).getMessage())
-                .isEqualTo("RemoteException: errorCode with instance ID errorId");
+        RemoteException ex = new RemoteException(error, 500);
+
+        String expectedMessage = "RemoteException: errorCode with instance ID errorId";
+        assertThat(ex.getMessage()).isEqualTo(expectedMessage + ": {parameter1=foo, parameter2=bar}");
+        assertThat(ex.getLogMessage()).isEqualTo(expectedMessage);
+        assertThat(ex.getArgs()).containsExactly(
+                UnsafeArg.of("parameter1", "foo"),
+                UnsafeArg.of("parameter2", "bar"));
     }
 }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
@@ -38,26 +38,42 @@ public final class ServiceExceptionTest {
                 UnsafeArg.of("arg3", null)};
         ServiceException ex = new ServiceException(ERROR, args);
 
-        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg2=2, arg3=null}");
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getArgs()).containsExactly(args);
     }
 
     @Test
     public void testExceptionMessageWithDuplicateKeys() {
-        ServiceException ex = new ServiceException(ERROR, SafeArg.of("arg1", "foo"), SafeArg.of("arg1", 2));
+        Arg<?>[] args = {
+                SafeArg.of("arg1", "foo"),
+                SafeArg.of("arg1", 2)};
+        ServiceException ex = new ServiceException(ERROR, args);
+
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg1=2}");
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getArgs()).containsExactly(args);
     }
 
     @Test
     public void testExceptionMessageWithUnsafeArgs() {
-        ServiceException ex = new ServiceException(ERROR, UnsafeArg.of("arg1", 1), SafeArg.of("arg2", 2));
+        Arg<?>[] args = {
+                UnsafeArg.of("arg1", 1),
+                SafeArg.of("arg2", 2)};
+        ServiceException ex = new ServiceException(ERROR, args);
+
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getArgs()).containsExactly(args);
     }
 
     @Test
     public void testExceptionMessageWithNoArgs() {
         ServiceException ex = new ServiceException(ERROR);
+
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getArgs()).isEmpty();
     }
 
     @Test
@@ -71,6 +87,7 @@ public final class ServiceExceptionTest {
     @Test
     public void testStatus() {
         ServiceException ex = new ServiceException(ERROR);
+
         assertThat(ex.getErrorType().httpErrorCode()).isEqualTo(400);
     }
 


### PR DESCRIPTION
## Before this PR
The implementations of `RemoteException` and `ServiceException` are not consistent:
- `RemoteException` does not implement `SafeLoggable`, `ServiceException` does
- `RemoteException#getMessage` does not include the parameters, `ServiceException#getMessage` does

## After this PR
The implementations of `RemoteException` and `ServiceException` are more consistent:
- Both implement `SafeLoggable`. `getLogMessage` does not include any args/parameters.
- `getMessage` includes all args/parameters, including unsafe args.

This is slightly different than #227 because this PR adds the parameters to the `RemoteException` message.