### PR TITLE
[improvement] Add 401 Unauthorized ErrorType

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
@@ -36,6 +36,7 @@ public abstract class ErrorType {
             Pattern.compile(String.format("%s:%s", UPPER_CAMEL_CASE, UPPER_CAMEL_CASE));
 
     public enum Code {
+        UNAUTHORIZED(401),
         PERMISSION_DENIED(403),
         INVALID_ARGUMENT(400),
         NOT_FOUND(404),
@@ -54,6 +55,8 @@ public abstract class ErrorType {
         }
     }
 
+    public static final ErrorType UNAUTHORIZED =
+            createInternal(Code.UNAUTHORIZED, "Default:Unauthorized");
     public static final ErrorType PERMISSION_DENIED =
             createInternal(Code.PERMISSION_DENIED, "Default:PermissionDenied");
     public static final ErrorType INVALID_ARGUMENT =

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ErrorTypeTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ErrorTypeTest.java
@@ -61,6 +61,7 @@ public final class ErrorTypeTest {
 
     @Test
     public void testDefaultErrorTypeHttpErrorCodes() throws Exception {
+        assertThat(ErrorType.UNAUTHORIZED.httpErrorCode()).isEqualTo(401);
         assertThat(ErrorType.PERMISSION_DENIED.httpErrorCode()).isEqualTo(403);
         assertThat(ErrorType.INVALID_ARGUMENT.httpErrorCode()).isEqualTo(400);
         assertThat(ErrorType.NOT_FOUND.httpErrorCode()).isEqualTo(404);


### PR DESCRIPTION
Palantir's authentication service uses 401 in the expected way, but currently clients have to manually propagate these. This PR allows us to add default 401 propagation in `RemoteExceptionMapper`, similar to how we propagate 403s.