### PR TITLE
Add parameters to RemoteException message

### DIFF
--- a/changelog/@unreleased/pr-337.v2.yml
+++ b/changelog/@unreleased/pr-337.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: RemoteException now implements SafeLoggable with behavior identical
+    to ServiceException.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/337

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -18,8 +18,12 @@ package com.palantir.conjure.java.api.errors;
 
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.UnsafeArg;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * An exception thrown by an RPC client to indicate remote/server-side failure.
@@ -29,6 +33,18 @@ public final class RemoteException extends RuntimeException implements SafeLogga
 
     private final SerializableError error;
     private final int status;
+
+    private final String noArgsMessage;
+    private final List<Arg<?>> args; // unmodifiable
+
+    public RemoteException(SerializableError error, int status) {
+        super(renderUnsafeMessage(error));
+
+        this.error = error;
+        this.status = status;
+        this.noArgsMessage = renderNoArgsMessage(error);
+        this.args = copyArgsToUnmodifiableList(error);
+    }
 
     /** Returns the error thrown by a remote process which caused an RPC call to fail. */
     public SerializableError getError() {
@@ -40,27 +56,56 @@ public final class RemoteException extends RuntimeException implements SafeLogga
         return status;
     }
 
-    public RemoteException(SerializableError error, int status) {
-        super(error.errorCode().equals(error.errorName())
-                ? String.format("RemoteException: %s with instance ID %s", error.errorCode(), error.errorInstanceId())
-                : String.format("RemoteException: %s (%s) with instance ID %s",
-                        error.errorCode(),
-                        error.errorName(),
-                        error.errorInstanceId()));
-
-        this.error = error;
-        this.status = status;
-    }
-
     @Override
     public String getLogMessage() {
-        return getMessage();
+        return noArgsMessage;
     }
 
     @Override
     public List<Arg<?>> getArgs() {
-        // RemoteException explicitly does not support arguments because they have already been recorded
-        // on the service which produced the causal SerializableError.
-        return Collections.emptyList();
+        return args;
+    }
+
+    private static List<Arg<?>> copyArgsToUnmodifiableList(SerializableError error) {
+        Map<String, String> parameters = error.parameters();
+
+        List<Arg<?>> argsList = new ArrayList<>(parameters.size());
+        for (Entry<String, String> parameter : parameters.entrySet()) {
+            argsList.add(UnsafeArg.of(parameter.getKey(), parameter.getValue()));
+        }
+        return Collections.unmodifiableList(argsList);
+    }
+
+    private static String renderUnsafeMessage(SerializableError error) {
+        String message = renderNoArgsMessage(error);
+        Map<String, String> parameters = error.parameters();
+
+        if (parameters.size() == 0) {
+            return message;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(message).append(": {");
+        boolean first = true;
+        for (Entry<String, String> parameter : parameters.entrySet()) {
+            if (first) {
+                first = false;
+            } else {
+                builder.append(", ");
+            }
+            builder.append(parameter.getKey()).append("=").append(parameter.getValue());
+        }
+        builder.append("}");
+
+        return builder.toString();
+    }
+
+    private static String renderNoArgsMessage(SerializableError error) {
+        return error.errorCode().equals(error.errorName())
+                ? String.format("RemoteException: %s with instance ID %s", error.errorCode(), error.errorInstanceId())
+                : String.format("RemoteException: %s (%s) with instance ID %s",
+                        error.errorCode(),
+                        error.errorName(),
+                        error.errorInstanceId());
     }
 }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
@@ -30,11 +30,9 @@ import javax.annotation.Nullable;
 public final class ServiceException extends RuntimeException implements SafeLoggable {
 
     private final ErrorType errorType;
-    private final List<Arg<?>> args; // unmodifiable
-
     private final String errorInstanceId;
-    private final String unsafeMessage;
     private final String noArgsMessage;
+    private final List<Arg<?>> args; // unmodifiable
 
     /**
      * Creates a new exception for the given error. All {@link com.palantir.logsafe.Arg parameters} are
@@ -47,13 +45,12 @@ public final class ServiceException extends RuntimeException implements SafeLogg
     /** As above, but additionally records the cause of this exception. */
     public ServiceException(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
         // TODO(rfink): Memoize formatting?
-        super(cause);
+        super(renderUnsafeMessage(errorType, args), cause);
 
         this.errorInstanceId = generateErrorInstanceId(cause);
         this.errorType = errorType;
         // Note that instantiators cannot mutate List<> args since it comes through copyToList in all code paths.
-        this.args = copyToUnmodifiableList(args);
-        this.unsafeMessage = renderUnsafeMessage(errorType, args);
+        this.args = copyArgsToUnmodifiableList(args);
         this.noArgsMessage = renderNoArgsMessage(errorType);
     }
 
@@ -65,12 +62,6 @@ public final class ServiceException extends RuntimeException implements SafeLogg
     /** A unique identifier for (this instance of) this error. */
     public String getErrorInstanceId() {
         return errorInstanceId;
-    }
-
-    @Override
-    public String getMessage() {
-        // Including all args here since any logger not configured with safe-logging will log this message.
-        return unsafeMessage;
     }
 
     @Override
@@ -94,10 +85,10 @@ public final class ServiceException extends RuntimeException implements SafeLogg
         return getArgs();
     }
 
-    private static <T> List<T> copyToUnmodifiableList(T[] elements) {
-        List<T> list = new ArrayList<>(elements.length);
-        Collections.addAll(list, elements);
-        return Collections.unmodifiableList(list);
+    private static List<Arg<?>> copyArgsToUnmodifiableList(Arg<?>[] args) {
+        List<Arg<?>> argsList = new ArrayList<>(args.length);
+        Collections.addAll(argsList, args);
+        return Collections.unmodifiableList(argsList);
     }
 
     private static String renderUnsafeMessage(ErrorType errorType, Arg<?>... args) {
@@ -114,7 +105,6 @@ public final class ServiceException extends RuntimeException implements SafeLogg
             if (i > 0) {
                 builder.append(", ");
             }
-
             builder.append(arg.getName()).append("=").append(arg.getValue());
         }
         builder.append("}");

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
@@ -39,26 +39,42 @@ public final class ServiceExceptionTest {
                 UnsafeArg.of("arg3", null)};
         ServiceException ex = new ServiceException(ERROR, args);
 
-        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg2=2, arg3=null}");
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getArgs()).containsExactly(args);
     }
 
     @Test
     public void testExceptionMessageWithDuplicateKeys() {
-        ServiceException ex = new ServiceException(ERROR, SafeArg.of("arg1", "foo"), SafeArg.of("arg1", 2));
+        Arg<?>[] args = {
+                SafeArg.of("arg1", "foo"),
+                SafeArg.of("arg1", 2)};
+        ServiceException ex = new ServiceException(ERROR, args);
+
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg1=2}");
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getArgs()).containsExactly(args);
     }
 
     @Test
     public void testExceptionMessageWithUnsafeArgs() {
-        ServiceException ex = new ServiceException(ERROR, UnsafeArg.of("arg1", 1), SafeArg.of("arg2", 2));
+        Arg<?>[] args = {
+                UnsafeArg.of("arg1", 1),
+                SafeArg.of("arg2", 2)};
+        ServiceException ex = new ServiceException(ERROR, args);
+
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getArgs()).containsExactly(args);
     }
 
     @Test
     public void testExceptionMessageWithNoArgs() {
         ServiceException ex = new ServiceException(ERROR);
+
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getArgs()).isEmpty();
     }
 
     @Test
@@ -72,6 +88,7 @@ public final class ServiceExceptionTest {
     @Test
     public void testStatus() {
         ServiceException ex = new ServiceException(ERROR);
+
         assertThat(ex.getErrorType().httpErrorCode()).isEqualTo(400);
     }
 


### PR DESCRIPTION
Fixes #226 

## Before this PR
The implementations of `RemoteException` and `ServiceException` are not consistent:
- `RemoteException` does not implement `SafeLoggable`, `ServiceException` does
- `RemoteException#getMessage` does not include the parameters, `ServiceException#getMessage` does

## After this PR
The implementations of `RemoteException` and `ServiceException` are more consistent:
- Both implement `SafeLoggable`. `getLogMessage` does not include any args/parameters.
- `getMessage` includes all args/parameters, including unsafe args.

This is slightly different than #227 because this PR adds the parameters to the `RemoteException` message.