### PR TITLE
fix #347: ServiceException retains causal `errorInstanceId`

### DIFF
--- a/changelog/@unreleased/pr-348.v2.yml
+++ b/changelog/@unreleased/pr-348.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'fix #347: ServiceException retains causal `errorInstanceId`'
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/348

--- a/changelog/@unreleased/pr-348.v2.yml
+++ b/changelog/@unreleased/pr-348.v2.yml
@@ -1,5 +1,8 @@
 type: improvement
 improvement:
-  description: 'fix #347: ServiceException retains causal `errorInstanceId`'
+  description: ServiceException retains the `errorInstanceId` from its cause, allowing RemoteExceptions
+    to be caught and used as the cause for as more specific ServiceException without sacrificing observability.
+    In most cases a single error identifier query is sufficient to discover the root cause of a failure
+    instead of individually requesting each segment back to the root.
   links:
   - https://github.com/palantir/conjure-java-runtime-api/pull/348

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
@@ -101,4 +101,16 @@ public final class ServiceExceptionTest {
         ServiceException parent = new ServiceException(ERROR, intermediate);
         assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getError().errorInstanceId());
     }
+
+    @Test
+    public void testCircularCause() {
+        RuntimeException first = new RuntimeException();
+        RuntimeException second = new RuntimeException(first);
+        // Yes, you can do this. In practice it's often more subtle when libraries attempt to piece together
+        // more helpful exception chains and encounter unexpected edge cases.
+        first.initCause(second);
+        // invoke getErrorInstanceId to ensure this is tested even if future developers
+        // optimize generation to occur lazily.
+        assertThat(new ServiceException(ERROR, second).getErrorInstanceId()).isNotNull();
+    }
 }


### PR DESCRIPTION
## Before this PR
See #347

## After this PR
==COMMIT_MSG==
fix #347: ServiceException retains causal `errorInstanceId`
==COMMIT_MSG==

