### PR TITLE
Fix #226: RemoteException messages are safe loggable

### DIFF
--- a/changelog/@unreleased/pr-353.v2.yml
+++ b/changelog/@unreleased/pr-353.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: RemoteException messages are safe loggable
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/353

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -16,10 +16,15 @@
 
 package com.palantir.conjure.java.api.errors;
 
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * An exception thrown by an RPC client to indicate remote/server-side failure.
  */
-public final class RemoteException extends RuntimeException {
+public final class RemoteException extends RuntimeException implements SafeLoggable {
     private static final long serialVersionUID = 1L;
 
     private final SerializableError error;
@@ -45,5 +50,17 @@ public final class RemoteException extends RuntimeException {
 
         this.error = error;
         this.status = status;
+    }
+
+    @Override
+    public String getLogMessage() {
+        return getMessage();
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        // RemoteException explicitly does not support arguments because they have already been recorded
+        // on the service which produced the causal SerializableError.
+        return Collections.emptyList();
     }
 }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
@@ -63,4 +63,30 @@ public final class RemoteExceptionTest {
         assertThat(new RemoteException(error, 500).getMessage())
                 .isEqualTo("RemoteException: errorCode with instance ID errorId");
     }
+
+    @Test
+    public void testLogMessageMessage() {
+        SerializableError error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .errorInstanceId("errorId")
+                .build();
+        RemoteException remoteException = new RemoteException(error, 500);
+        assertThat(remoteException.getLogMessage())
+                .isEqualTo(remoteException.getMessage())
+                .isEqualTo("RemoteException: errorCode (errorName) with instance ID errorId");
+    }
+
+    @Test
+    public void testArgsIsEmpty() {
+        RemoteException remoteException = new RemoteException(new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .errorInstanceId("errorId")
+                .putParameters("param", "value")
+                .build(), 500);
+        assertThat(remoteException.getArgs())
+                .describedAs("RemoteException does not support parameters by design")
+                .isEmpty();
+    }
 }


### PR DESCRIPTION
Previously RemoteException data was only recorded (safely) if the
exception was propagated to a conjure exception mapper. Many
use cases (exceptions from an executor, for example) do not result
in this behavior. Catching an exception and logging it should allow
us to look up the root cause by ID.

## After this PR
==COMMIT_MSG==
RemoteException messages are safe loggable
==COMMIT_MSG==

