### PR TITLE
Add 401 Unauthorized ErrorType

### DIFF
--- a/changelog/@unreleased/pr-356.v2.yml
+++ b/changelog/@unreleased/pr-356.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add an `UNAUTHORIZED` error type
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/356

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
@@ -36,6 +36,7 @@ public abstract class ErrorType {
             Pattern.compile(String.format("%s:%s", UPPER_CAMEL_CASE, UPPER_CAMEL_CASE));
 
     public enum Code {
+        UNAUTHORIZED(401),
         PERMISSION_DENIED(403),
         INVALID_ARGUMENT(400),
         NOT_FOUND(404),
@@ -54,6 +55,8 @@ public abstract class ErrorType {
         }
     }
 
+    public static final ErrorType UNAUTHORIZED =
+            createInternal(Code.UNAUTHORIZED, "Default:Unauthorized");
     public static final ErrorType PERMISSION_DENIED =
             createInternal(Code.PERMISSION_DENIED, "Default:PermissionDenied");
     public static final ErrorType INVALID_ARGUMENT =

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ErrorTypeTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ErrorTypeTest.java
@@ -61,6 +61,7 @@ public final class ErrorTypeTest {
 
     @Test
     public void testDefaultErrorTypeHttpErrorCodes() throws Exception {
+        assertThat(ErrorType.UNAUTHORIZED.httpErrorCode()).isEqualTo(401);
         assertThat(ErrorType.PERMISSION_DENIED.httpErrorCode()).isEqualTo(403);
         assertThat(ErrorType.INVALID_ARGUMENT.httpErrorCode()).isEqualTo(400);
         assertThat(ErrorType.NOT_FOUND.httpErrorCode()).isEqualTo(404);


### PR DESCRIPTION
## Before this PR

Can't throw errors with HTTP status code 401.

See https://github.com/palantir/conjure/pull/367 for context.

## After this PR

==COMMIT_MSG==
This change enables generating errors using the `UNAUTHORIZED` error type, which maps to HTTP status code 401.
==COMMIT_MSG==

## Potential complications

We need to make sure that existing clients can handle `RemoteException` with status code 401.
Most of our clients are java, and so at the very minimum we should check that the current conjure-java-runtime clients would [parse](https://github.com/palantir/conjure-java-runtime/blob/950e91d168fe86573604b962c4bcdddb251dde2e/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemoteExceptionResponseHandler.java#L61-L62) and [forward](https://github.com/palantir/conjure-java-runtime/blob/950e91d168fe86573604b962c4bcdddb251dde2e/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java#L54) it correctly, which it seems like they do (there's no special validation on either `SerializableError.errorCode()` or `RemoteException.getStatus()`).