### PR TITLE
Redact password and token-related fields

### DIFF
--- a/changelog/@unreleased/pr-368.v2.yml
+++ b/changelog/@unreleased/pr-368.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Password and token-related fields are now annotated as redacted, which
     should prevent the field values from appearing in toString output.
   links:

--- a/changelog/@unreleased/pr-368.v2.yml
+++ b/changelog/@unreleased/pr-368.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Password and token-related fields are now annotated as redacted, which
+    should prevent the field values from appearing in toString output.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/368

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/BasicCredentials.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/BasicCredentials.java
@@ -30,6 +30,7 @@ public abstract class BasicCredentials {
     @Value.Parameter
     public abstract String username();
 
+    @Value.Redacted
     @Value.Parameter
     public abstract String password();
 

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/PartialServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/PartialServiceConfiguration.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.tokens.auth.BearerToken;
 import java.util.List;
 import java.util.Optional;
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 @Immutable
@@ -33,6 +34,7 @@ public interface PartialServiceConfiguration {
 
     /** The API token to be used to interact with the service. */
     @JsonAlias("api-token")
+    @Value.Redacted
     Optional<BearerToken> apiToken();
 
     /** The SSL configuration needed to interact with the service. */

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
@@ -30,6 +30,7 @@ import org.immutables.value.Value;
 @ImmutablesStyle
 public interface ServiceConfiguration {
 
+    @Value.Redacted
     Optional<BearerToken> apiToken();
 
     SslConfiguration security();

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServicesConfigBlock.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServicesConfigBlock.java
@@ -24,6 +24,7 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.tokens.auth.BearerToken;
 import java.util.Map;
 import java.util.Optional;
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 /**
@@ -44,6 +45,7 @@ public abstract class ServicesConfigBlock {
      */
     @JsonProperty("apiToken")
     @JsonAlias("api-token")
+    @Value.Redacted
     public abstract Optional<BearerToken> defaultApiToken();
 
     /**

--- a/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
@@ -51,6 +51,7 @@ public abstract class SslConfiguration {
     public abstract Optional<Path> keyStorePath();
 
     @JsonAlias("key-store-password")
+    @Value.Redacted
     public abstract Optional<String> keyStorePassword();
 
     @SuppressWarnings("checkstyle:designforextension")


### PR DESCRIPTION
Remove sensitive fields from toString output to prevent credential
leakage into logs and other similar places.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Conjure consumers that log config classes might inadvertently leak passwords or tokens to disk

## After this PR
==COMMIT_MSG==
Password and token-related fields are now annotated as redacted, which should prevent the field values from appearing in toString output.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Consumers that expect passwords and tokens to appear in toString output will now need to call the respective getters explicitly.
