### PR TITLE
Add utility to propagate RemoteExceptions

### DIFF
--- a/changelog/@unreleased/pr-370.v2.yml
+++ b/changelog/@unreleased/pr-370.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+fix:
+  description: Adds utility to propagate original RemoteExceptions back to clients.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/370

--- a/errors/build.gradle
+++ b/errors/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation "com.palantir.safe-logging:preconditions"
 
     testCompile project(":extras:jackson-support")
+    testCompile project(":test-utils")
     testCompile "org.assertj:assertj-core"
     testCompile "org.apache.commons:commons-lang3"
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureThrowables.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureThrowables.java
@@ -33,12 +33,12 @@ public final class ConjureThrowables {
      * try {
      *     service.someMethod();
      * } catch (RemoteException e) {
-     *     ConjureThrowables.propagateIfErrorTypeOf(e, ServiceErrors.REMOTE_ERROR_TYPE);
+     *     ConjureThrowables.propagateIfErrorTypeEquals(e, ServiceErrors.REMOTE_ERROR_TYPE);
      *     throw e;
      * }
      * </pre>
      */
-    public static void propagateIfErrorTypeOf(RemoteException remoteException, ErrorType errorType) {
+    public static void propagateIfErrorTypeEquals(RemoteException remoteException, ErrorType errorType) {
         if (hasErrorType(remoteException, errorType)) {
             throw new ServiceException(errorType, remoteException, argsFromRemoteException(remoteException));
         }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureThrowables.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureThrowables.java
@@ -62,7 +62,10 @@ public final class ConjureThrowables {
     }
 
     private static Arg<?>[] argsFromRemoteException(RemoteException remoteException) {
-        return remoteException.getError().parameters().entrySet().stream()
+        return remoteException.getError()
+                .parameters()
+                .entrySet()
+                .stream()
                 .map(entry -> UnsafeArg.of(entry.getKey(), entry.getValue()))
                 .toArray(Arg<?>[]::new);
     }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureThrowables.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureThrowables.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+public class ConjureThrowables {
+}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
@@ -77,7 +77,10 @@ public abstract class ErrorType {
     public abstract String name();
 
     /** The HTTP error code used to convey this error to HTTP clients. */
-    public abstract int httpErrorCode();
+    @Value.Derived
+    public int httpErrorCode() {
+        return code().httpErrorCode;
+    }
 
     @Value.Check
     final void check() {
@@ -113,7 +116,6 @@ public abstract class ErrorType {
         return ImmutableErrorType.builder()
                 .code(code)
                 .name(name)
-                .httpErrorCode(code.httpErrorCode)
                 .build();
     }
 }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureThrowablesTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureThrowablesTest.java
@@ -37,10 +37,11 @@ public class ConjureThrowablesTest {
                 .build();
         RemoteException remoteException = new RemoteException(error, 400);
 
-        assertThatServiceExceptionThrownBy(() -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ERROR_TYPE))
-                .hasType(ERROR_TYPE)
-                .hasErrorInstanceId(ERROR_INSTANCE_ID)
-                .hasArgs(UnsafeArg.of("arg", "value"));
+        assertThatServiceExceptionThrownBy(
+                () -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ERROR_TYPE))
+                        .hasType(ERROR_TYPE)
+                        .hasErrorInstanceId(ERROR_INSTANCE_ID)
+                        .hasArgs(UnsafeArg.of("arg", "value"));
     }
 
     @Test
@@ -53,7 +54,7 @@ public class ConjureThrowablesTest {
 
         assertThatServiceExceptionThrownBy(
                 () -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ErrorType.INVALID_ARGUMENT))
-                .hasType(ErrorType.INVALID_ARGUMENT);
+                        .hasType(ErrorType.INVALID_ARGUMENT);
     }
 
     @Test
@@ -64,8 +65,9 @@ public class ConjureThrowablesTest {
                 .build();
         RemoteException remoteException = new RemoteException(error, 400);
 
-        assertThatCode(() -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ErrorType.INVALID_ARGUMENT))
-                .doesNotThrowAnyException();
+        assertThatCode(
+                () -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ErrorType.INVALID_ARGUMENT))
+                        .doesNotThrowAnyException();
     }
 
     @Test
@@ -76,7 +78,8 @@ public class ConjureThrowablesTest {
                 .build();
         RemoteException remoteException = new RemoteException(error, 400);
 
-        assertThatCode(() -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ErrorType.INVALID_ARGUMENT))
-                .doesNotThrowAnyException();
+        assertThatCode(
+                () -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ErrorType.INVALID_ARGUMENT))
+                        .doesNotThrowAnyException();
     }
 }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureThrowablesTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureThrowablesTest.java
@@ -1,0 +1,82 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import static com.palantir.conjure.java.api.testing.Assertions.assertThatServiceExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.palantir.logsafe.UnsafeArg;
+import org.junit.jupiter.api.Test;
+
+public class ConjureThrowablesTest {
+
+    private static final ErrorType ERROR_TYPE = ErrorType.create(ErrorType.Code.CUSTOM_CLIENT, "Namespace:MyDesc");
+    private static final String ERROR_INSTANCE_ID = "85afe977";
+
+    @Test
+    public void testThrowsIfErrorTypeMatches() {
+        SerializableError error = new SerializableError.Builder()
+                .errorName("Namespace:MyDesc")
+                .errorCode("CUSTOM_CLIENT")
+                .errorInstanceId(ERROR_INSTANCE_ID)
+                .putParameters("arg", "value")
+                .build();
+        RemoteException remoteException = new RemoteException(error, 400);
+
+        assertThatServiceExceptionThrownBy(() -> ConjureThrowables.propagateIfErrorTypeOf(remoteException, ERROR_TYPE))
+                .hasType(ERROR_TYPE)
+                .hasErrorInstanceId(ERROR_INSTANCE_ID)
+                .hasArgs(UnsafeArg.of("arg", "value"));
+    }
+
+    @Test
+    public void testThrowsIfDefaultErrorTypeMatches() {
+        SerializableError error = new SerializableError.Builder()
+                .errorName("Default:InvalidArgument")
+                .errorCode("INVALID_ARGUMENT")
+                .build();
+        RemoteException remoteException = new RemoteException(error, 400);
+
+        assertThatServiceExceptionThrownBy(
+                () -> ConjureThrowables.propagateIfErrorTypeOf(remoteException, ErrorType.INVALID_ARGUMENT))
+                .hasType(ErrorType.INVALID_ARGUMENT);
+    }
+
+    @Test
+    public void testDoesntThrowIfErrorTypeMismatch() {
+        SerializableError error = new SerializableError.Builder()
+                .errorName("Namespace:MyDesc")
+                .errorCode("CUSTOM_CLIENT")
+                .build();
+        RemoteException remoteException = new RemoteException(error, 400);
+
+        assertThatCode(() -> ConjureThrowables.propagateIfErrorTypeOf(remoteException, ErrorType.INVALID_ARGUMENT))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testDoesntThrowIfErrorTypeInvalid() {
+        SerializableError error = new SerializableError.Builder()
+                .errorName("Invalid")
+                .errorCode("INVALID")
+                .build();
+        RemoteException remoteException = new RemoteException(error, 400);
+
+        assertThatCode(() -> ConjureThrowables.propagateIfErrorTypeOf(remoteException, ErrorType.INVALID_ARGUMENT))
+                .doesNotThrowAnyException();
+    }
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureThrowablesTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureThrowablesTest.java
@@ -37,7 +37,7 @@ public class ConjureThrowablesTest {
                 .build();
         RemoteException remoteException = new RemoteException(error, 400);
 
-        assertThatServiceExceptionThrownBy(() -> ConjureThrowables.propagateIfErrorTypeOf(remoteException, ERROR_TYPE))
+        assertThatServiceExceptionThrownBy(() -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ERROR_TYPE))
                 .hasType(ERROR_TYPE)
                 .hasErrorInstanceId(ERROR_INSTANCE_ID)
                 .hasArgs(UnsafeArg.of("arg", "value"));
@@ -52,7 +52,7 @@ public class ConjureThrowablesTest {
         RemoteException remoteException = new RemoteException(error, 400);
 
         assertThatServiceExceptionThrownBy(
-                () -> ConjureThrowables.propagateIfErrorTypeOf(remoteException, ErrorType.INVALID_ARGUMENT))
+                () -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ErrorType.INVALID_ARGUMENT))
                 .hasType(ErrorType.INVALID_ARGUMENT);
     }
 
@@ -64,7 +64,7 @@ public class ConjureThrowablesTest {
                 .build();
         RemoteException remoteException = new RemoteException(error, 400);
 
-        assertThatCode(() -> ConjureThrowables.propagateIfErrorTypeOf(remoteException, ErrorType.INVALID_ARGUMENT))
+        assertThatCode(() -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ErrorType.INVALID_ARGUMENT))
                 .doesNotThrowAnyException();
     }
 
@@ -76,7 +76,7 @@ public class ConjureThrowablesTest {
                 .build();
         RemoteException remoteException = new RemoteException(error, 400);
 
-        assertThatCode(() -> ConjureThrowables.propagateIfErrorTypeOf(remoteException, ErrorType.INVALID_ARGUMENT))
+        assertThatCode(() -> ConjureThrowables.propagateIfErrorTypeEquals(remoteException, ErrorType.INVALID_ARGUMENT))
                 .doesNotThrowAnyException();
     }
 }

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
@@ -50,6 +50,12 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         return this;
     }
 
+    public final ServiceExceptionAssert hasErrorInstanceId(String errorInstanceId) {
+        isNotNull();
+        failIfNotEqual("Expected errorInstanceId to be %s, but found %s", errorInstanceId, actual.getErrorInstanceId());
+        return this;
+    }
+
     private void failIfNotEqual(String message, Object expected, Object actual) {
         if (!Objects.equals(expected, actual)) {
             failWithMessage(message, expected, actual);


### PR DESCRIPTION
## Before this PR
In a request `A->B->C`, it's unreasonably difficult for B to propagate back a RemoteException it received from C. The common use case here is that C returns a 400 error that A could action, but B converts it to a `Default:Internal` error.

That's fine for the default. But if B identifies an error worth forwarding it has two cumbersome options:
* wrap RemoteExceptions in a different type and handle in a new ExceptionMapper
* re-throw RemoteExceptions as ServiceExceptions with a new error type and convert the SerializableError's parameters to UnsafeArgs

## After this PR
==COMMIT_MSG==
Adds utility to propagate original RemoteExceptions back to clients.
==COMMIT_MSG==
```java
try {
  remote.method()
} catch (RemoteException e) {
  ConjureThrowables.propagateIfErrorTypeEquals(e, RemoteErrors.ERROR);
  throw e;
}
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

