### PR TITLE
Annotate test-utils AssertJ Assertions with CheckReturnValue

### DIFF
--- a/changelog/@unreleased/pr-407.v2.yml
+++ b/changelog/@unreleased/pr-407.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Annotate test-utils AssertJ Assertions with CheckReturnValue to match
+    assertj-core.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/407

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
@@ -21,7 +21,10 @@ import com.palantir.conjure.java.api.errors.ServiceException;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.internal.Failures;
+import org.assertj.core.util.CanIgnoreReturnValue;
+import org.assertj.core.util.CheckReturnValue;
 
+@CheckReturnValue
 public class Assertions extends org.assertj.core.api.Assertions {
 
     Assertions() {}
@@ -34,12 +37,14 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new RemoteExceptionAssert(actual);
     }
 
+    @CanIgnoreReturnValue
     public static ServiceExceptionAssert assertThatServiceExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
         Throwable throwable = AssertionsForClassTypes.catchThrowable(shouldRaiseThrowable);
         checkThrowableIsOfType(throwable, ServiceException.class);
         return new ServiceExceptionAssert((ServiceException) throwable);
     }
 
+    @CanIgnoreReturnValue
     public static RemoteExceptionAssert assertThatRemoteExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
         Throwable throwable = AssertionsForClassTypes.catchThrowable(shouldRaiseThrowable);
         checkThrowableIsOfType(throwable, RemoteException.class);


### PR DESCRIPTION
The `@CheckReturnValue` annotation is not inherited from the
superclass.

==COMMIT_MSG==
 Annotate test-utils AssertJ Assertions with CheckReturnValue to match assertj-core.
==COMMIT_MSG==

