### PR TITLE
Improvement: Assume default type is PEM if trustStorePath/keyStorePath doesn't have jks extension

### DIFF
--- a/changelog/@unreleased/pr-426.v2.yml
+++ b/changelog/@unreleased/pr-426.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Try to be smarter about keystore and truststore type and only have
+    them be jks if files end with jks extension
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/426

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactoryTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactoryTests.java
@@ -43,8 +43,8 @@ public final class ServiceConfigurationFactoryTests {
 
     private static final BearerToken apiToken = BearerToken.valueOf("token");
     private static final BearerToken defaultApiToken = BearerToken.valueOf("defaultToken");
-    private static final SslConfiguration security = SslConfiguration.of(mock(Path.class));
-    private static final SslConfiguration defaultSecurity = SslConfiguration.of(mock(Path.class));
+    private static final SslConfiguration security = SslConfiguration.of(Paths.get("store.jks"));
+    private static final SslConfiguration defaultSecurity = SslConfiguration.of(Paths.get("default-store.jks"));
     private static final HumanReadableDuration connectTimeout = HumanReadableDuration.seconds(1);
     private static final HumanReadableDuration defaultConnectTimeout = HumanReadableDuration.seconds(2);
     private static final HumanReadableDuration readTimeout = HumanReadableDuration.minutes(1);

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactoryTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactoryTests.java
@@ -18,7 +18,6 @@ package com.palantir.conjure.java.api.config.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -32,7 +31,6 @@ import com.palantir.conjure.java.api.ext.jackson.ShimJdk7Module;
 import com.palantir.tokens.auth.BearerToken;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Optional;

--- a/ssl-config/build.gradle
+++ b/ssl-config/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.palantir.revapi'
 
 dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
+    implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'
 
     testImplementation project(':extras:jackson-support')

--- a/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
@@ -35,8 +35,6 @@ public abstract class SslConfiguration {
         PUPPET
     }
 
-    private static final StoreType DEFAULT_STORE_TYPE = StoreType.JKS;
-
     @JsonAlias("trust-store-path")
     public abstract Path trustStorePath();
 
@@ -44,7 +42,11 @@ public abstract class SslConfiguration {
     @Value.Default
     @JsonAlias("trust-store-type")
     public StoreType trustStoreType() {
-        return DEFAULT_STORE_TYPE;
+        if (trustStorePath().getFileName().toString().endsWith("jks")) {
+            return StoreType.JKS;
+        } else {
+            return StoreType.PEM;
+        }
     }
 
     @JsonAlias("key-store-path")
@@ -58,7 +60,11 @@ public abstract class SslConfiguration {
     @Value.Default
     @JsonAlias("key-store-type")
     public StoreType keyStoreType() {
-        return DEFAULT_STORE_TYPE;
+        if (keyStorePath().map(keyStore ->  keyStore.getFileName().toString().endsWith("jks")).orElse(true)) {
+            return StoreType.JKS;
+        } else {
+            return StoreType.PEM;
+        }
     }
 
     @JsonAlias("key-store-key-alias")

--- a/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
@@ -45,7 +45,7 @@ public abstract class SslConfiguration {
     @Value.Default
     @JsonAlias("trust-store-type")
     public StoreType trustStoreType() {
-        if (PEM_EXTENSIONS.stream().anyMatch(ext -> trustStorePath().getFileName().toString().endsWith(ext))) {
+        if (isPemExtension(trustStorePath())) {
             return StoreType.PEM;
         } else {
             return StoreType.JKS;
@@ -63,9 +63,7 @@ public abstract class SslConfiguration {
     @Value.Default
     @JsonAlias("key-store-type")
     public StoreType keyStoreType() {
-        if (keyStorePath().map(keyStore -> PEM_EXTENSIONS.stream()
-                .anyMatch(ext -> keyStore.getFileName().toString().endsWith(ext)))
-                .orElse(false)) {
+        if (keyStorePath().map(this::isPemExtension).orElse(false)) {
             return StoreType.PEM;
         } else {
             return StoreType.JKS;
@@ -86,6 +84,10 @@ public abstract class SslConfiguration {
             throw new SafeIllegalArgumentException(
                     "keyStorePath must be present if keyStoreKeyAlias is present");
         }
+    }
+
+    protected final boolean isPemExtension(Path filePath) {
+        return PEM_EXTENSIONS.stream().anyMatch(ext -> filePath.getFileName().toString().endsWith(ext));
     }
 
     public static SslConfiguration of(Path trustStorePath) {

--- a/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
@@ -60,7 +60,7 @@ public abstract class SslConfiguration {
     @Value.Default
     @JsonAlias("key-store-type")
     public StoreType keyStoreType() {
-        if (keyStorePath().map(keyStore ->  keyStore.getFileName().toString().endsWith("jks")).orElse(true)) {
+        if (keyStorePath().map(keyStore -> keyStore.getFileName().toString().endsWith("jks")).orElse(true)) {
             return StoreType.JKS;
         } else {
             return StoreType.PEM;

--- a/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
+++ b/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
@@ -91,4 +91,33 @@ public final class SslConfigurationTest {
                 .keyStoreType(SslConfiguration.StoreType.PEM)
                 .build()).doesNotThrowAnyException();
     }
+
+    @Test
+    public void testDefaultTypeIsPem() {
+        SslConfiguration sslConfiguration = SslConfiguration.builder()
+                .trustStorePath(Paths.get("cert.cer"))
+                .keyStorePath(Paths.get("key.pem"))
+                .keyStorePassword("password")
+                .build();
+        assertThat(sslConfiguration.trustStoreType()).isEqualTo(SslConfiguration.StoreType.PEM);
+        assertThat(sslConfiguration.keyStoreType()).isEqualTo(SslConfiguration.StoreType.PEM);
+    }
+
+    @Test
+    public void testDefaultTypeIsJKS() {
+        SslConfiguration sslConfiguration = SslConfiguration.of(Paths.get("truststore.jks"));
+        assertThat(sslConfiguration.trustStoreType()).isEqualTo(SslConfiguration.StoreType.JKS);
+        assertThat(sslConfiguration.keyStoreType()).isEqualTo(SslConfiguration.StoreType.JKS);
+    }
+
+    @Test
+    public void testDefaultType() {
+        SslConfiguration sslConfiguration = SslConfiguration.builder()
+                .trustStorePath(Paths.get("cert.cer"))
+                .keyStorePath(Paths.get("keystore.jks"))
+                .keyStorePassword("password")
+                .build();
+        assertThat(sslConfiguration.trustStoreType()).isEqualTo(SslConfiguration.StoreType.PEM);
+        assertThat(sslConfiguration.keyStoreType()).isEqualTo(SslConfiguration.StoreType.JKS);
+    }   
 }

--- a/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
+++ b/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
@@ -119,5 +119,5 @@ public final class SslConfigurationTest {
                 .build();
         assertThat(sslConfiguration.trustStoreType()).isEqualTo(SslConfiguration.StoreType.PEM);
         assertThat(sslConfiguration.keyStoreType()).isEqualTo(SslConfiguration.StoreType.JKS);
-    }   
+    }
 }

--- a/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
+++ b/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
@@ -104,7 +104,7 @@ public final class SslConfigurationTest {
     }
 
     @Test
-    public void testDefaultTypeIsJKS() {
+    public void testDefaultTypeIsJks() {
         SslConfiguration sslConfiguration = SslConfiguration.of(Paths.get("truststore.jks"));
         assertThat(sslConfiguration.trustStoreType()).isEqualTo(SslConfiguration.StoreType.JKS);
         assertThat(sslConfiguration.keyStoreType()).isEqualTo(SslConfiguration.StoreType.JKS);


### PR DESCRIPTION
## Before this PR
We assume keystore and truststore type is jks regardlesss of what file it is

## After this PR
==COMMIT_MSG==
Try to be smarter about keystore and truststore type and only have them be jks if files end with jks extension
==COMMIT_MSG==

## Possible downsides?
Someone was relying on current behaviour for jks files without .jks extension
