### PR TITLE
Improvement: Only require keystore password for jks stores

### DIFF
--- a/changelog/@unreleased/pr-427.v2.yml
+++ b/changelog/@unreleased/pr-427.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Don't require passwords for non jks keystores
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/427

--- a/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
@@ -67,9 +67,9 @@ public abstract class SslConfiguration {
 
     @Value.Check
     protected final void check() {
-        if (keyStorePath().isPresent() != keyStorePassword().isPresent()) {
+        if (keyStorePath().isPresent() && keyStoreType().equals(StoreType.JKS) != keyStorePassword().isPresent()) {
             throw new SafeIllegalArgumentException(
-                    "keyStorePath and keyStorePassword must both be present or both be absent");
+                    "keyStorePassword must be present if keyStoreType is JKS");
         }
         if (keyStoreKeyAlias().isPresent() && !keyStorePath().isPresent()) {
             throw new SafeIllegalArgumentException(

--- a/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
@@ -67,7 +67,7 @@ public abstract class SslConfiguration {
 
     @Value.Check
     protected final void check() {
-        if (keyStorePath().isPresent() && keyStoreType().equals(StoreType.JKS) != keyStorePassword().isPresent()) {
+        if (keyStorePath().isPresent() && keyStoreType().equals(StoreType.JKS) && !keyStorePassword().isPresent()) {
             throw new SafeIllegalArgumentException(
                     "keyStorePassword must be present if keyStoreType is JKS");
         }

--- a/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
+++ b/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
@@ -79,8 +79,8 @@ public final class SslConfigurationTest {
                 .keyStorePath(Paths.get("keystore.jks"))
                 .keyStoreType(SslConfiguration.StoreType.JKS)
                 .build())
-                .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasMessage("keyStorePassword must be present if keyStoreType is JKS");
+                        .isInstanceOf(SafeIllegalArgumentException.class)
+                        .hasMessage("keyStorePassword must be present if keyStoreType is JKS");
     }
 
     @Test
@@ -88,6 +88,7 @@ public final class SslConfigurationTest {
         assertThatCode(() -> SslConfiguration.builder()
                 .trustStorePath(Paths.get("truststore.jks"))
                 .keyStorePath(Paths.get("key.pem"))
+                .keyStoreType(SslConfiguration.StoreType.PEM)
                 .build()).doesNotThrowAnyException();
     }
 }

--- a/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
+++ b/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
@@ -17,9 +17,12 @@
 package com.palantir.conjure.java.api.config.ssl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.conjure.java.api.ext.jackson.ObjectMappers;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
@@ -67,5 +70,24 @@ public final class SslConfigurationTest {
                 .isEqualTo(serialized);
         assertThat(MAPPER.readValue(deserializedKebabCase, SslConfiguration.class))
                 .isEqualTo(serialized);
+    }
+
+    @Test
+    public void jksKeystorePassword() {
+        assertThatThrownBy(() -> SslConfiguration.builder()
+                .trustStorePath(Paths.get("truststore.jks"))
+                .keyStorePath(Paths.get("keystore.jks"))
+                .keyStoreType(SslConfiguration.StoreType.JKS)
+                .build())
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessage("keyStorePassword must be present if keyStoreType is JKS");
+    }
+
+    @Test
+    public void nonJksKeystorePassword() {
+        assertThatCode(() -> SslConfiguration.builder()
+                .trustStorePath(Paths.get("truststore.jks"))
+                .keyStorePath(Paths.get("key.pem"))
+                .build()).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## Before this PR
We required password for any kind of keystore

## After this PR
==COMMIT_MSG==
Don't require passwords for non jks keystores
==COMMIT_MSG==

## Possible downsides?
Code that uses those configurations might need to be altered but it doesn't break existing setups just relaxes constraints for future use
