### PR TITLE
Add a new `enable-http2` flag to the service configuration 

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -3,4 +3,21 @@ versionOverrides:
   com.palantir.conjure.java.api:ssl-config:2.8.0: "2.7.0"
   com.palantir.conjure.java.api:errors:2.8.0: "2.7.0"
   com.palantir.conjure.java.api:service-config:2.8.0: "2.7.0"
-acceptedBreaks: {}
+acceptedBreaks:
+  "2.10.0":
+    com.palantir.conjure.java.api:service-config:
+    - code: "java.method.addedToInterface"
+      old: null
+      new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.api.config.service.ServiceConfiguration::enableHttp2()"
+      justification: "Added a new field to ServiceConfiguration, @Immutables annotated\
+        \ types are not meant for extension"
+    - code: "java.method.addedToInterface"
+      old: null
+      new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.api.config.service.PartialServiceConfiguration::enableHttp2()"
+      justification: "Added a new field to ServiceConfiguration, @Immutables annotated\
+        \ types are not meant for extension"
+    - code: "java.method.abstractMethodAdded"
+      old: null
+      new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.api.config.service.ServicesConfigBlock::defaultEnableHttp2()"
+      justification: "Added a new field to ServiceConfiguration, @Immutables annotated\
+        \ types are not meant for extension"

--- a/changelog/@unreleased/pr-443.v2.yml
+++ b/changelog/@unreleased/pr-443.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add a new `enable-http2` flag to the service configuration
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/443

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/PartialServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/PartialServiceConfiguration.java
@@ -71,6 +71,13 @@ public interface PartialServiceConfiguration {
     Optional<Boolean> enableGcmCipherSuites();
 
     /**
+     * Whether or not to allow the http/2 protocol. A default value is not guaranteed, and may differ between
+     * client implementations.
+     */
+    @JsonAlias("enable-http2")
+    Optional<Boolean> enableHttp2();
+
+    /**
      * Enables fallback to common name verification, defaults to false.
      *
      * @deprecated This option will be removed by the end of 2019. Certificates are expected to provide valid SANs.

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java
@@ -49,6 +49,8 @@ public interface ServiceConfiguration {
 
     Optional<Boolean> enableGcmCipherSuites();
 
+    Optional<Boolean> enableHttp2();
+
     Optional<Boolean> fallbackToCommonNameVerification();
 
     Optional<ProxyConfiguration> proxy();

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactory.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactory.java
@@ -86,6 +86,7 @@ public final class ServiceConfigurationFactory {
                         .map(t -> Duration.ofMillis(t.toMilliseconds())))
                 .proxy(orElse(partial.proxyConfiguration(), services.defaultProxyConfiguration()))
                 .enableGcmCipherSuites(orElse(partial.enableGcmCipherSuites(), services.defaultEnableGcmCipherSuites()))
+                .enableHttp2(orElse(partial.enableHttp2(), services.defaultEnableHttp2()))
                 .fallbackToCommonNameVerification(orElse(
                         partial.fallbackToCommonNameVerification(), services.defaultFallbackToCommonNameVerification()))
                 .build();

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServicesConfigBlock.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServicesConfigBlock.java
@@ -88,6 +88,11 @@ public abstract class ServicesConfigBlock {
     @JsonAlias("enable-gcm-cipher-suites")
     public abstract Optional<Boolean> defaultEnableGcmCipherSuites();
 
+    /** Default enablement of http/2.. */
+    @JsonProperty("enableHttp2")
+    @JsonAlias("enable-http2")
+    public abstract Optional<Boolean> defaultEnableHttp2();
+
     /**
      * Default fallback to common name verification, defaults to false.
      *

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/PartialServiceConfigurationTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/PartialServiceConfigurationTest.java
@@ -48,7 +48,7 @@ public final class PartialServiceConfigurationTest {
                 + "\"keyStorePassword\":null,\"keyStoreType\":\"JKS\",\"keyStoreKeyAlias\":null},\"uris\":[\"uri1\"],"
                 + "\"connectTimeout\":\"1 day\",\"readTimeout\":\"1 day\",\"writeTimeout\":\"1 day\","
                 + "\"maxNumRetries\":5,\"backoffSlotSize\":\"1 day\","
-                + "\"enableGcmCipherSuites\":null,\"fallbackToCommonNameVerification\":null,"
+                + "\"enableGcmCipherSuites\":null,\"enableHttp2\":null,\"fallbackToCommonNameVerification\":null,"
                 + "\"proxyConfiguration\":{\"hostAndPort\":\"host:80\",\"credentials\":null,"
                 + "\"type\":\"HTTP\"}}";
         String kebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
@@ -57,7 +57,8 @@ public final class PartialServiceConfigurationTest {
                 + "\"connect-timeout\":\"1 day\",\"read-timeout\":\"1 day\",\"write-timeout\":\"1 day\","
                 + "\"max-num-retries\":5,\"backoff-slot-size\":\"1 day\","
                 + "\"uris\":[\"uri1\"],\"proxy-configuration\":{\"host-and-port\":\"host:80\",\"credentials\":null},"
-                + "\"enable-gcm-cipher-suites\":null,\"fallback-to-common-name-verification\":null}";
+                + "\"enable-gcm-cipher-suites\":null,\"enable-http2\":null,"
+                + "\"fallback-to-common-name-verification\":null}";
 
         assertThat(mapper.writeValueAsString(serialized)).isEqualTo(camelCase);
         assertThat(mapper.readValue(camelCase, PartialServiceConfiguration.class))
@@ -72,11 +73,12 @@ public final class PartialServiceConfigurationTest {
                 PartialServiceConfiguration.builder().build();
         String camelCase = "{\"apiToken\":null,\"security\":null,\"uris\":[],\"connectTimeout\":null,"
                 + "\"readTimeout\":null,\"writeTimeout\":null,\"maxNumRetries\":null,\"backoffSlotSize\":null,"
-                + "\"enableGcmCipherSuites\":null,\"fallbackToCommonNameVerification\":null,"
+                + "\"enableGcmCipherSuites\":null,\"enableHttp2\":null,\"fallbackToCommonNameVerification\":null,"
                 + "\"proxyConfiguration\":null}";
         String kebabCase = "{\"api-token\":null,\"security\":null,\"connect-timeout\":null,"
                 + "\"read-timeout\":null,\"write-timeout\":null,\"max-num-retries\":null,\"backoff-slot-size\":null,"
-                + "\"enable-gcm-cipher-suites\":null,\"fallback-to-common-name-verification\":null,"
+                + "\"enable-gcm-cipher-suites\":null,\"enable-http2\":null,"
+                + "\"fallback-to-common-name-verification\":null,"
                 + "\"uris\":[],\"proxy-configuration\":null}";
 
         assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(serialized))

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactoryTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ServiceConfigurationFactoryTests.java
@@ -192,17 +192,18 @@ public final class ServiceConfigurationFactoryTests {
                 + "\"keyStorePassword\":null,\"keyStoreType\":\"JKS\",\"keyStoreKeyAlias\":null},\"services\":"
                 + "{\"service\":{\"apiToken\":null,\"security\":null,\"uris\":[\"uri\"],\"connectTimeout\":null,"
                 + "\"readTimeout\":null,\"writeTimeout\":null,\"maxNumRetries\":null,\"backoffSlotSize\":null,"
-                + "\"enableGcmCipherSuites\":null,\"fallbackToCommonNameVerification\":null,"
+                + "\"enableGcmCipherSuites\":null,\"enableHttp2\":null,\"fallbackToCommonNameVerification\":null,"
                 + "\"proxyConfiguration\":null}},\"proxyConfiguration\":"
                 + "{\"hostAndPort\":\"host:80\",\"credentials\":null,\"type\":\"HTTP\"},\"connectTimeout\":\"1 day\","
                 + "\"readTimeout\":\"1 day\",\"writeTimeout\":\"1 day\",\"backoffSlotSize\":\"1 day\","
-                + "\"enableGcmCipherSuites\":null,\"fallbackToCommonNameVerification\":null}";
+                + "\"enableGcmCipherSuites\":null,\"enableHttp2\":null,\"fallbackToCommonNameVerification\":null}";
         String kebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
                 + "{\"trust-store-path\":\"truststore.jks\",\"trust-store-type\":\"JKS\",\"key-store-path\":null,"
                 + "\"key-store-password\":null,\"key-store-type\":\"JKS\",\"key-store-key-alias\":null},\"services\":"
                 + "{\"service\":{\"apiToken\":null,\"security\":null,\"connect-timeout\":null,\"read-timeout\":null,"
                 + "\"write-timeout\":null,\"max-num-retries\":null,\"backoffSlotSize\":null,\"uris\":[\"uri\"],"
-                + "\"enable-gcm-cipher-suites\":null,\"fallback-to-common-name-verification\":null,"
+                + "\"enable-gcm-cipher-suites\":null,\"enable-http2\":null,"
+                + "\"fallback-to-common-name-verification\":null,"
                 + "\"proxy-configuration\":null}},\"proxy-configuration\":"
                 + "{\"host-and-port\":\"host:80\",\"credentials\":null},\"connect-timeout\":\"1 day\","
                 + "\"read-timeout\":\"1 day\",\"write-timeout\":\"1 day\",\"backoff-slot-size\":\"1 day\"}";
@@ -220,10 +221,11 @@ public final class ServiceConfigurationFactoryTests {
         ServicesConfigBlock deserialized = ServicesConfigBlock.builder().build();
         String serializedCamelCase = "{\"apiToken\":null,\"security\":null,\"services\":{},"
                 + "\"proxyConfiguration\":null,\"connectTimeout\":null,\"readTimeout\":null,\"writeTimeout\":null,"
-                + "\"backoffSlotSize\":null,\"enableGcmCipherSuites\":null,\"fallbackToCommonNameVerification\":null}";
+                + "\"backoffSlotSize\":null,\"enableGcmCipherSuites\":null,\"enableHttp2\":null,"
+                + "\"fallbackToCommonNameVerification\":null}";
         String serializedKebabCase = "{\"api-token\":null,\"security\":null,\"services\":{},"
                 + "\"proxy-configuration\":null,\"connect-timeout\":null,\"read-timeout\":null,\"write-timeout\":null,"
-                + "\"backoff-slot-size\":null,\"enable-gcm-cipher-suites\":null,"
+                + "\"backoff-slot-size\":null,\"enable-gcm-cipher-suites\":null,\"enable-http2\":null,"
                 + "\"fallback-to-common-name-verification\":null}";
 
         assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(deserialized))


### PR DESCRIPTION
## Before this PR
No way to configure http/2 support in configuration

## After this PR
==COMMIT_MSG==
Add a new `enable-http2` flag to the service configuration 
==COMMIT_MSG==

## Possible downsides?
larger api surface.

