### PR TITLE
SslConfiguration validates that keyStorePassword requires keyStorePath

### DIFF
--- a/changelog/@unreleased/pr-449.v2.yml
+++ b/changelog/@unreleased/pr-449.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: SslConfiguration validates that keyStorePassword requires keyStorePath
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/449

--- a/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java
@@ -76,6 +76,9 @@ public abstract class SslConfiguration {
 
     @Value.Check
     protected final void check() {
+        if (keyStorePassword().isPresent() && !keyStorePath().isPresent()) {
+            throw new SafeIllegalArgumentException("keyStorePath must be present if a keyStorePassword is provided");
+        }
         if (keyStorePath().isPresent()
                 && keyStoreType().equals(StoreType.JKS)
                 && !keyStorePassword().isPresent()) {

--- a/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
+++ b/ssl-config/src/test/java/com/palantir/conjure/java/api/config/ssl/SslConfigurationTest.java
@@ -82,6 +82,17 @@ public final class SslConfigurationTest {
     }
 
     @Test
+    public void keystorePasswordWithoutPath() {
+        assertThatThrownBy(() -> SslConfiguration.builder()
+                        .trustStorePath(Paths.get("truststore.jks"))
+                        .keyStoreType(SslConfiguration.StoreType.PEM)
+                        .keyStorePassword("password")
+                        .build())
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessage("keyStorePath must be present if a keyStorePassword is provided");
+    }
+
+    @Test
     public void nonJksKeystorePassword() {
         assertThatCode(() -> SslConfiguration.builder()
                         .trustStorePath(Paths.get("truststore.jks"))


### PR DESCRIPTION
Fix SslConfiguration validation regression introduced by #427

## Before this PR
Key store password could be provided without a key store path.

## After this PR
==COMMIT_MSG==
SslConfiguration validates that keyStorePassword requires keyStorePath
==COMMIT_MSG==

## Possible downsides?
none, this re-introduces the previous behavior.

