### PR TITLE
Add ProxySelection type FROM_ENVIRONMENT

### DIFF
--- a/changelog/@unreleased/pr-535.v2.yml
+++ b/changelog/@unreleased/pr-535.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Add new proxy selection type "FROM_ENVIRONMENT" that will be used in
+    `conjure-java-runtime` to instantiate proxy selection based on environment variable
+    `https_proxy`.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/535

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -38,6 +38,9 @@ public abstract class ProxyConfiguration {
 
     public enum Type {
 
+        /** Use default JVM's proxy selector. */
+        DEFAULT,
+
         /** Use a direct connection. This option will bypass any JVM-level configured proxy settings. */
         DIRECT,
 
@@ -87,6 +90,11 @@ public abstract class ProxyConfiguration {
                 HostAndPort host = HostAndPort.fromString(hostAndPort().get());
                 Preconditions.checkArgument(
                         host.hasPort(), "Given hostname does not contain a port number", SafeArg.of("hostname", host));
+                break;
+            case DEFAULT:
+                Preconditions.checkArgument(
+                        !hostAndPort().isPresent() && !credentials().isPresent(),
+                        "Neither credential nor host-and-port may be configured for DEFAULT proxies");
                 break;
             case DIRECT:
                 Preconditions.checkArgument(

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -38,11 +38,11 @@ public abstract class ProxyConfiguration {
 
     public enum Type {
 
-        /** Use default JVM's proxy selector. */
-        FROM_ENVIRONMENT,
-
         /** Use a direct connection. This option will bypass any JVM-level configured proxy settings. */
         DIRECT,
+
+        /** Use default JVM's proxy selector. */
+        FROM_ENVIRONMENT,
 
         /**
          * Use an http-proxy specified by {@link ProxyConfiguration#hostAndPort()} and (optionally)

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -100,8 +100,7 @@ public abstract class ProxyConfiguration {
                 break;
             case FROM_ENVIRONMENT:
                 Preconditions.checkArgument(
-                        !hostAndPort().isPresent() && !credentials().isPresent(),
-                        "Neither credential nor host-and-port may be configured for FROM_ENVIRONMENT proxies");
+                        !hostAndPort().isPresent(), "Host-and-port may not be configured for FROM_ENVIRONMENT proxies");
                 break;
             default:
                 throw new SafeIllegalStateException("Unrecognized case; this is a library bug");

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -41,7 +41,9 @@ public abstract class ProxyConfiguration {
         /** Use a direct connection. This option will bypass any JVM-level configured proxy settings. */
         DIRECT,
 
-        /** Use default JVM's proxy selector. */
+        /**
+         * Use an http-proxy with {@link ProxyConfiguration#hostAndPort()} extracted from environment's "https_proxy".
+         */
         FROM_ENVIRONMENT,
 
         /**

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -91,15 +91,15 @@ public abstract class ProxyConfiguration {
                 Preconditions.checkArgument(
                         host.hasPort(), "Given hostname does not contain a port number", SafeArg.of("hostname", host));
                 break;
-            case FROM_ENVIRONMENT:
-                Preconditions.checkArgument(
-                        !hostAndPort().isPresent() && !credentials().isPresent(),
-                        "Neither credential nor host-and-port may be configured for FROM_ENVIRONMENT proxies");
-                break;
             case DIRECT:
                 Preconditions.checkArgument(
                         !hostAndPort().isPresent() && !credentials().isPresent(),
                         "Neither credential nor host-and-port may be configured for DIRECT proxies");
+                break;
+            case FROM_ENVIRONMENT:
+                Preconditions.checkArgument(
+                        !hostAndPort().isPresent() && !credentials().isPresent(),
+                        "Neither credential nor host-and-port may be configured for FROM_ENVIRONMENT proxies");
                 break;
             default:
                 throw new SafeIllegalStateException("Unrecognized case; this is a library bug");

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -39,7 +39,7 @@ public abstract class ProxyConfiguration {
     public enum Type {
 
         /** Use default JVM's proxy selector. */
-        DEFAULT,
+        FROM_ENVIRONMENT,
 
         /** Use a direct connection. This option will bypass any JVM-level configured proxy settings. */
         DIRECT,
@@ -91,10 +91,10 @@ public abstract class ProxyConfiguration {
                 Preconditions.checkArgument(
                         host.hasPort(), "Given hostname does not contain a port number", SafeArg.of("hostname", host));
                 break;
-            case DEFAULT:
+            case FROM_ENVIRONMENT:
                 Preconditions.checkArgument(
                         !hostAndPort().isPresent() && !credentials().isPresent(),
-                        "Neither credential nor host-and-port may be configured for DEFAULT proxies");
+                        "Neither credential nor host-and-port may be configured for FROM_ENVIRONMENT proxies");
                 break;
             case DIRECT:
                 Preconditions.checkArgument(

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
@@ -60,6 +60,16 @@ public final class ProxyConfigurationTests {
     }
 
     @Test
+    public void testDeserializationFromEnvironment() throws Exception {
+        URL resource = Resources.getResource("configs/proxy-config-from-environment.yml");
+        ProxyConfiguration config = mapper.readValue(resource, ProxyConfiguration.class);
+        assertThat(config)
+                .isEqualTo(ProxyConfiguration.builder()
+                        .type(ProxyConfiguration.Type.FROM_ENVIRONMENT)
+                        .build());
+    }
+
+    @Test
     public void testDeserializationMesh() throws Exception {
         URL resource = Resources.getResource("configs/proxy-config-mesh.yml");
         ProxyConfiguration config = mapper.readValue(resource, ProxyConfiguration.class);
@@ -78,6 +88,16 @@ public final class ProxyConfigurationTests {
                         .build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Neither credential nor host-and-port may be configured for DIRECT proxies");
+    }
+
+    @Test
+    public void testFromEnvironmentProxyWithHostAndPort() {
+        assertThatThrownBy(() -> new ProxyConfiguration.Builder()
+                        .hostAndPort("squid:3128")
+                        .type(ProxyConfiguration.Type.FROM_ENVIRONMENT)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Host-and-port may not be configured for FROM_ENVIRONMENT proxies");
     }
 
     @Test

--- a/service-config/src/test/resources/configs/proxy-config-from-environment.yml
+++ b/service-config/src/test/resources/configs/proxy-config-from-environment.yml
@@ -1,0 +1,1 @@
+type: FROM_ENVIRONMENT


### PR DESCRIPTION
Addresses #160.
Add new proxy selection type "FROM_ENVIRONMENT" that will be used in `conjure-java-runtime` to instantiate proxy selection based on environment variable `https_proxy`.

https://github.com/palantir/conjure-java-runtime/pull/1566 for the change in `c-j-r`.