### PR TITLE
Add Helper for PartialServiceConfiguration

### DIFF
--- a/changelog/@unreleased/pr-540.v2.yml
+++ b/changelog/@unreleased/pr-540.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add Helper class to create PartialServiceConfiguration from ServiceConfiguration.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/540

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/HumanReadableDuration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/HumanReadableDuration.java
@@ -107,6 +107,10 @@ public final class HumanReadableDuration implements Comparable<HumanReadableDura
         return new HumanReadableDuration(count, unit);
     }
 
+    public static HumanReadableDuration fromJavaDuration(Duration duration) {
+        return new HumanReadableDuration(duration.toNanos(), TimeUnit.NANOSECONDS);
+    }
+
     private final long count;
     private final TimeUnit unit;
 

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/PartialServiceConfigurations.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/PartialServiceConfigurations.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.config.service;
+
+/**
+ * Utility class to create {@link PartialServiceConfiguration} objects.
+ */
+public final class PartialServiceConfigurations {
+
+    private PartialServiceConfigurations() {}
+
+    /**
+     * Creates a {@link PartialServiceConfiguration} object out of a {@link ServiceConfiguration} one.
+     */
+    public static PartialServiceConfiguration fromServiceConfiguration(ServiceConfiguration serviceConfiguration) {
+        return builderFromServiceConfiguration(serviceConfiguration).build();
+    }
+
+    /**
+     * Creates a {@link PartialServiceConfiguration.Builder} from a {@link ServiceConfiguration}.
+     */
+    public static PartialServiceConfiguration.Builder builderFromServiceConfiguration(
+            ServiceConfiguration serviceConfiguration) {
+        return PartialServiceConfiguration.builder()
+                .apiToken(serviceConfiguration.apiToken())
+                .backoffSlotSize(serviceConfiguration.backoffSlotSize().map(HumanReadableDuration::fromJavaDuration))
+                .connectTimeout(serviceConfiguration.connectTimeout().map(HumanReadableDuration::fromJavaDuration))
+                .enableGcmCipherSuites(serviceConfiguration.enableGcmCipherSuites())
+                .enableHttp2(serviceConfiguration.enableHttp2())
+                .fallbackToCommonNameVerification(serviceConfiguration.fallbackToCommonNameVerification())
+                .maxNumRetries(serviceConfiguration.maxNumRetries())
+                .proxyConfiguration(serviceConfiguration.proxy())
+                .readTimeout(serviceConfiguration.readTimeout().map(HumanReadableDuration::fromJavaDuration))
+                .security(serviceConfiguration.security())
+                .uris(serviceConfiguration.uris())
+                .writeTimeout(serviceConfiguration.writeTimeout().map(HumanReadableDuration::fromJavaDuration));
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
There is no way of creating a `PartialServiceConfiguration` object from a `ServiceConfiguration` one even though they share all the fields.
The fields all have the same name except `proxy` and some have slightly different types and that makes it problematic to just switch between the two types without having to match all the fields one by one.

## After this PR
==COMMIT_MSG==
Add Helper class to create PartialServiceConfiguration from ServiceConfiguration.
==COMMIT_MSG==

