### PR TITLE
unsafe log unknown remote exception body

### DIFF
--- a/changelog/@unreleased/pr-563.v2.yml
+++ b/changelog/@unreleased/pr-563.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: add the body of the UnknownRemoteException as a unsafe parameter
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/563

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
@@ -19,6 +19,8 @@ package com.palantir.conjure.java.api.errors;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.UnsafeArg;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -52,6 +54,9 @@ public final class UnknownRemoteException extends RuntimeException implements Sa
 
     @Override
     public List<Arg<?>> getArgs() {
-        return Collections.singletonList(SafeArg.of("status", getStatus()));
+        List<Arg<?>> args = new ArrayList<>(2);
+        args.add(SafeArg.of("status", getStatus()));
+        args.add(UnsafeArg.of("body", getBody()));
+        return Collections.unmodifiableList(args);
     }
 }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/UnknownRemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/UnknownRemoteExceptionTest.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.api.errors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import org.junit.jupiter.api.Test;
 
 class UnknownRemoteExceptionTest {
@@ -34,6 +35,6 @@ class UnknownRemoteExceptionTest {
     @Test
     public void testArgsContainsStatus() {
         UnknownRemoteException exception = new UnknownRemoteException(404, "not found");
-        assertThat(exception.getArgs()).containsOnly(SafeArg.of("status", 404));
+        assertThat(exception.getArgs()).containsExactly(SafeArg.of("status", 404), UnsafeArg.of("body", "not found"));
     }
 }


### PR DESCRIPTION
## Before this PR
We captured the body of an unknown remote exception and promptly ignored it.

## After this PR
==COMMIT_MSG==
add the body of the UnknownRemoteException as a unsafe parameter 
==COMMIT_MSG==

## Possible downsides?
N/A

