### PR TITLE
HasExternalSource

### DIFF
--- a/changelog/@unreleased/pr-590.v2.yml
+++ b/changelog/@unreleased/pr-590.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add a marker interface that can be used to mark exceptions as being
+    caused by an external problem.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/590

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/HasExternalSource.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/HasExternalSource.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+/**
+ * A marker interface that indicates that an exception has a cause external to this JVM (e.g. is caused by some kind
+ * of RPC). The intended use of this is to provide diagnostic information as to the cause of a problem, and allow
+ * upstream services to ignore third party issues for purposes of alerting.
+ */
+public interface HasExternalSource {}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 /** An exception thrown by an RPC client to indicate remote/server-side failure. */
-public final class RemoteException extends RuntimeException implements SafeLoggable {
+public final class RemoteException extends RuntimeException implements SafeLoggable, HasExternalSource {
     private static final long serialVersionUID = 1L;
 
     private final SerializableError error;

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 /** An exception thrown by an RPC client to indicate remote/server-side failure from a non-remoting server. */
-public final class UnknownRemoteException extends RuntimeException implements SafeLoggable {
+public final class UnknownRemoteException extends RuntimeException implements SafeLoggable, HasExternalSource {
     private static final long serialVersionUID = 1L;
 
     private final int status;


### PR DESCRIPTION
Add a simple interface that can be used to mark exceptions as being caused by an external problem (e.g. a third service failing). This enables us to internally monitor each service for exceptions that _aren't_ caused by an external problem (higher signal). This means that a library like AtlasDB can trivially make its AtlasDbDependencyException (thrown when e.g. Cassandra is broken) be picked up as an external problem.