### PR TITLE
improvement: move errorInstanceId from exception message into exception args

### DIFF
--- a/changelog/@unreleased/pr-604.v2.yml
+++ b/changelog/@unreleased/pr-604.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: move `RemoteException`s errorInstanceId from exception message into
+    exception args
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/604

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.api.errors;
 
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +28,7 @@ public final class RemoteException extends RuntimeException implements SafeLogga
 
     private final SerializableError error;
     private final int status;
+    private final List<Arg<?>> args;
 
     /** Returns the error thrown by a remote process which caused an RPC call to fail. */
     public SerializableError getError() {
@@ -41,14 +43,12 @@ public final class RemoteException extends RuntimeException implements SafeLogga
     public RemoteException(SerializableError error, int status) {
         super(
                 error.errorCode().equals(error.errorName())
-                        ? String.format(
-                                "RemoteException: %s with instance ID %s", error.errorCode(), error.errorInstanceId())
-                        : String.format(
-                                "RemoteException: %s (%s) with instance ID %s",
-                                error.errorCode(), error.errorName(), error.errorInstanceId()));
+                        ? String.format("RemoteException: %s", error.errorCode())
+                        : String.format("RemoteException: %s (%s)", error.errorCode(), error.errorName()));
 
         this.error = error;
         this.status = status;
+        this.args = Collections.singletonList(SafeArg.of("errorInstanceId", error.errorInstanceId()));
     }
 
     @Override
@@ -60,6 +60,6 @@ public final class RemoteException extends RuntimeException implements SafeLogga
     public List<Arg<?>> getArgs() {
         // RemoteException explicitly does not support arguments because they have already been recorded
         // on the service which produced the causal SerializableError.
-        return Collections.emptyList();
+        return args;
     }
 }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -26,6 +26,8 @@ import java.util.List;
 public final class RemoteException extends RuntimeException implements SafeLoggable {
     private static final long serialVersionUID = 1L;
 
+    private final String message;
+    private final String stableMessage;
     private final SerializableError error;
     private final int status;
     private final List<Arg<?>> args;
@@ -41,19 +43,23 @@ public final class RemoteException extends RuntimeException implements SafeLogga
     }
 
     public RemoteException(SerializableError error, int status) {
-        super(
-                error.errorCode().equals(error.errorName())
-                        ? String.format("RemoteException: %s", error.errorCode())
-                        : String.format("RemoteException: %s (%s)", error.errorCode(), error.errorName()));
-
+        this.stableMessage = error.errorCode().equals(error.errorName())
+                ? String.format("RemoteException: %s", error.errorCode())
+                : String.format("RemoteException: %s (%s)", error.errorCode(), error.errorName());
+        this.message = this.stableMessage + " with instance ID " + error.errorInstanceId();
         this.error = error;
         this.status = status;
         this.args = Collections.singletonList(SafeArg.of("errorInstanceId", error.errorInstanceId()));
     }
 
     @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
     public String getLogMessage() {
-        return getMessage();
+        return stableMessage;
     }
 
     @Override

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
@@ -53,14 +53,16 @@ public final class RemoteExceptionTest {
                 .errorName("errorName")
                 .errorInstanceId("errorId")
                 .build();
-        assertThat(new RemoteException(error, 500).getMessage()).isEqualTo("RemoteException: errorCode (errorName)");
+        assertThat(new RemoteException(error, 500).getMessage())
+                .isEqualTo("RemoteException: errorCode (errorName) with instance ID errorId");
 
         error = new SerializableError.Builder()
                 .errorCode("errorCode")
                 .errorName("errorCode")
                 .errorInstanceId("errorId")
                 .build();
-        assertThat(new RemoteException(error, 500).getMessage()).isEqualTo("RemoteException: errorCode");
+        assertThat(new RemoteException(error, 500).getMessage())
+                .isEqualTo("RemoteException: errorCode with instance ID errorId");
     }
 
     @Test
@@ -71,9 +73,7 @@ public final class RemoteExceptionTest {
                 .errorInstanceId("errorId")
                 .build();
         RemoteException remoteException = new RemoteException(error, 500);
-        assertThat(remoteException.getLogMessage())
-                .isEqualTo(remoteException.getMessage())
-                .isEqualTo("RemoteException: errorCode (errorName)");
+        assertThat(remoteException.getLogMessage()).isEqualTo("RemoteException: errorCode (errorName)");
     }
 
     @Test

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.api.errors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.jupiter.api.Test;
 
@@ -52,16 +53,14 @@ public final class RemoteExceptionTest {
                 .errorName("errorName")
                 .errorInstanceId("errorId")
                 .build();
-        assertThat(new RemoteException(error, 500).getMessage())
-                .isEqualTo("RemoteException: errorCode (errorName) with instance ID errorId");
+        assertThat(new RemoteException(error, 500).getMessage()).isEqualTo("RemoteException: errorCode (errorName)");
 
         error = new SerializableError.Builder()
                 .errorCode("errorCode")
                 .errorName("errorCode")
                 .errorInstanceId("errorId")
                 .build();
-        assertThat(new RemoteException(error, 500).getMessage())
-                .isEqualTo("RemoteException: errorCode with instance ID errorId");
+        assertThat(new RemoteException(error, 500).getMessage()).isEqualTo("RemoteException: errorCode");
     }
 
     @Test
@@ -74,7 +73,7 @@ public final class RemoteExceptionTest {
         RemoteException remoteException = new RemoteException(error, 500);
         assertThat(remoteException.getLogMessage())
                 .isEqualTo(remoteException.getMessage())
-                .isEqualTo("RemoteException: errorCode (errorName) with instance ID errorId");
+                .isEqualTo("RemoteException: errorCode (errorName)");
     }
 
     @Test
@@ -87,8 +86,6 @@ public final class RemoteExceptionTest {
                         .putParameters("param", "value")
                         .build(),
                 500);
-        assertThat(remoteException.getArgs())
-                .describedAs("RemoteException does not support parameters by design")
-                .isEmpty();
+        assertThat(remoteException.getArgs()).containsExactly(SafeArg.of("errorInstanceId", "errorId"));
     }
 }


### PR DESCRIPTION
## Before this PR
We were attempting to perform some internal analysis on unique stacktraces but were running into issues since we grouped stacktraces textually and the error instance id appeared as part of the message of each remote exception

## After this PR

==COMMIT_MSG==
move `RemoteException`s errorInstanceId from exception message into exception args 
==COMMIT_MSG==

## Possible downsides?
It will be harder to debug issue if logging is not set up (i.e. args are logged) correctly since the message will not contain the error id

