### PR TITLE
ServiceException no longer throws NPE when null args are provided

### DIFF
--- a/changelog/@unreleased/pr-608.v2.yml
+++ b/changelog/@unreleased/pr-608.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: ServiceException no longer throws NPE when null args are provided
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/608

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
@@ -95,27 +95,37 @@ public final class ServiceException extends RuntimeException implements SafeLogg
     }
 
     private static <T> List<T> copyToUnmodifiableList(T[] elements) {
+        if (elements == null || elements.length == 0) {
+            return Collections.emptyList();
+        }
         List<T> list = new ArrayList<>(elements.length);
-        Collections.addAll(list, elements);
+        for (T item : elements) {
+            if (item != null) {
+                list.add(item);
+            }
+        }
         return Collections.unmodifiableList(list);
     }
 
     private static String renderUnsafeMessage(ErrorType errorType, Arg<?>... args) {
         String message = renderNoArgsMessage(errorType);
 
-        if (args.length == 0) {
+        if (args == null || args.length == 0) {
             return message;
         }
 
         StringBuilder builder = new StringBuilder();
+        boolean first = true;
         builder.append(message).append(": {");
-        for (int i = 0; i < args.length; i++) {
-            Arg<?> arg = args[i];
-            if (i > 0) {
-                builder.append(", ");
+        for (Arg<?> arg : args) {
+            if (arg != null) {
+                if (first) {
+                    first = false;
+                } else {
+                    builder.append(", ");
+                }
+                builder.append(arg.getName()).append("=").append(arg.getValue());
             }
-
-            builder.append(arg.getName()).append("=").append(arg.getValue());
         }
         builder.append("}");
 

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
@@ -53,6 +53,13 @@ public final class ServiceExceptionTest {
     }
 
     @Test
+    public void testExceptionMessageWithNullArg() {
+        ServiceException ex = new ServiceException(ERROR, UnsafeArg.of("arg1", 1), null, SafeArg.of("arg2", 2));
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
+        assertThat(ex.getArgs()).doesNotContainNull().hasSize(2);
+    }
+
+    @Test
     public void testExceptionMessageWithNoArgs() {
         ServiceException ex = new ServiceException(ERROR);
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG);


### PR DESCRIPTION
## Before this PR
The render method threw a NPE when an argument value was null. This exception destroys our ability to capture the root cause -- we must either set the original as a cause/suppressed-cause or provide as much data as possible.

It's clearly not ideal to have null arg values, however it's even worse if we're unable to diagnose the original problem based on logging, so we mustn't be opinionated here.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
ServiceException no longer throws NPE when null args are provided
==COMMIT_MSG==

See https://github.com/palantir/safe-logging/pull/492

## Possible downsides?
none.

