### PR TITLE
All QosExceptions are SafeLoggable

### DIFF
--- a/changelog/@unreleased/pr-612.v2.yml
+++ b/changelog/@unreleased/pr-612.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: All QosExceptions are now SafeLoggable
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/612

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  * service. Typically, this exception gets translated into appropriate error codes of the underlying transport layer,
  * e.g., HTTP status codes 429, 503, etc. in the case of HTTP transport.
  */
-public abstract class QosException extends RuntimeException implements SafeLoggable {
+public abstract class QosException extends RuntimeException {
 
     // Not meant for external subclassing.
     private QosException(String message) {
@@ -114,7 +114,7 @@ public abstract class QosException extends RuntimeException implements SafeLogga
     }
 
     /** See {@link #throttle}. */
-    public static final class Throttle extends QosException {
+    public static final class Throttle extends QosException implements SafeLoggable {
         private final Optional<Duration> retryAfter;
 
         private Throttle(Optional<Duration> retryAfter) {
@@ -148,7 +148,7 @@ public abstract class QosException extends RuntimeException implements SafeLogga
     }
 
     /** See {@link #retryOther}. */
-    public static final class RetryOther extends QosException {
+    public static final class RetryOther extends QosException implements SafeLoggable {
         private final URL redirectTo;
 
         private RetryOther(URL redirectTo) {
@@ -183,7 +183,7 @@ public abstract class QosException extends RuntimeException implements SafeLogga
     }
 
     /** See {@link #unavailable}. */
-    public static final class Unavailable extends QosException {
+    public static final class Unavailable extends QosException implements SafeLoggable {
         private static final String SERVER_UNAVAILABLE = "Server unavailable";
 
         private Unavailable() {


### PR DESCRIPTION
## Before this PR

I was just looking at an internal stacktrace and saw the message was redacted, which made me wonder what it was:

```
Caused by: com.palantir.conjure.java.api.errors.QosException$Throttle: {throwable1_message}
	at com.palantir.conjure.java.api.errors.QosException.throttle(QosException.java:60)
	at java.util.Optional.orElseGet(Optional.java:369)
	at com.palantir.conjure.java.dialogue.serde.ErrorDecoder.decode(ErrorDecoder.java:88)
```

Turns out there was nothing interesting in this, but it made me curious enough that I wasted 2 minutes opening up the QosException.java class.

## After this PR
==COMMIT_MSG==
All QosExceptions are now SafeLoggable
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

