### PR TITLE
Add ServiceExceptionAssert.hasArgsIncluding

### DIFF
--- a/changelog/@unreleased/pr-620.v2.yml
+++ b/changelog/@unreleased/pr-620.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Added `ServiceExceptionAssert.hasArgsIncluding`, a weaker form of `hasArgs`.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/620

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
@@ -56,6 +56,27 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         }
     }
 
+    public final ServiceExceptionAssert hasArgsIncluding(Arg<?>... args) {
+        isNotNull();
+
+        AssertableArgs actualArgs = new AssertableArgs(actual.getParameters());
+        AssertableArgs expectedArgs = new AssertableArgs(Arrays.asList(args));
+
+        failIfDoesNotContain(
+                "Expected safe args to contain %s, but found %s", expectedArgs.safeArgs, actualArgs.safeArgs);
+        failIfDoesNotContain(
+                "Expected unsafe args to contain %s, but found %s", expectedArgs.unsafeArgs, actualArgs.unsafeArgs);
+
+        return this;
+    }
+
+    private void failIfDoesNotContain(
+            String message, Map<String, Object> expectedArgs, Map<String, Object> actualArgs) {
+        if (!actualArgs.entrySet().containsAll(expectedArgs.entrySet())) {
+            failWithMessage(message, expectedArgs, actualArgs);
+        }
+    }
+
     private static final class AssertableArgs {
         private final Map<String, Object> safeArgs = new HashMap<>();
         private final Map<String, Object> unsafeArgs = new HashMap<>();

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
@@ -56,7 +56,7 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         }
     }
 
-    public final ServiceExceptionAssert hasArgsIncluding(Arg<?>... args) {
+    public final ServiceExceptionAssert containsArgs(Arg<?>... args) {
         isNotNull();
 
         AssertableArgs actualArgs = new AssertableArgs(actual.getParameters());

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
@@ -60,7 +60,8 @@ public class ServiceExceptionAssertTest {
         assertThatThrownBy(() -> Assertions.assertThat(
                                 new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
                         .containsArgs(UnsafeArg.of("a", "b")))
-                .isInstanceOf(AssertionError.class);
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Expected unsafe args to contain {a=b}, but found {c=d}");
 
         assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b")))
                         .containsArgs(SafeArg.of("c", "d")))

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
@@ -54,21 +54,21 @@ public class ServiceExceptionAssertTest {
                 .hasMessage("Expected unsafe args to be {c=d}, but found {a=b}");
 
         Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
-                .hasArgsIncluding(UnsafeArg.of("a", "b"));
+                .containsArgs(UnsafeArg.of("a", "b"));
 
         // Safety matters
         assertThatThrownBy(() -> Assertions.assertThat(
                                 new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
-                        .hasArgsIncluding(UnsafeArg.of("a", "b")))
+                        .containsArgs(UnsafeArg.of("a", "b")))
                 .isInstanceOf(AssertionError.class);
 
         assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b")))
-                        .hasArgsIncluding(SafeArg.of("c", "d")))
+                        .containsArgs(SafeArg.of("c", "d")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessage("Expected safe args to contain {c=d}, but found {a=b}");
 
         assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b")))
-                        .hasArgsIncluding(UnsafeArg.of("c", "d")))
+                        .containsArgs(UnsafeArg.of("c", "d")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessage("Expected unsafe args to contain {c=d}, but found {a=b}");
     }

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 public class ServiceExceptionAssertTest {
 
     @Test
-    public void testSanity() throws Exception {
+    public void testSanity() {
         ErrorType actualType = ErrorType.FAILED_PRECONDITION;
 
         Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
@@ -52,5 +52,24 @@ public class ServiceExceptionAssertTest {
                         .hasArgs(UnsafeArg.of("c", "d")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessage("Expected unsafe args to be {c=d}, but found {a=b}");
+
+        Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                .hasArgsIncluding(UnsafeArg.of("a", "b"));
+
+        // Safety matters
+        assertThatThrownBy(() -> Assertions.assertThat(
+                                new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                        .hasArgsIncluding(UnsafeArg.of("a", "b")))
+                .isInstanceOf(AssertionError.class);
+
+        assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b")))
+                        .hasArgsIncluding(SafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Expected safe args to contain {c=d}, but found {a=b}");
+
+        assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b")))
+                        .hasArgsIncluding(UnsafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Expected unsafe args to contain {c=d}, but found {a=b}");
     }
 }


### PR DESCRIPTION
## Before this PR
Using `hasArgs` required you to specify all args, which was not trivial if some args were non-deterministic.

## After this PR
==COMMIT_MSG==
Added `ServiceExceptionAssert.hasArgsIncluding`, a weaker form of `hasArgs`.
==COMMIT_MSG==

## Possible downsides?
N/A? Additive change.
