### PR TITLE
RemoteException.getMessage includes SerializableError parameters

### DIFF
--- a/changelog/@unreleased/pr-633.v2.yml
+++ b/changelog/@unreleased/pr-633.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: RemoteException.getMessage (unsafe message) includes SerializableError parameters. RemoteException.getLogMessage (safe) is not impacted.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/633

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
@@ -47,7 +47,7 @@ public final class RemoteExceptionTest {
     }
 
     @Test
-    public void testSuperMessage() {
+    public void testUnsafeMessage_differentCodeAndName() {
         SerializableError error = new SerializableError.Builder()
                 .errorCode("errorCode")
                 .errorName("errorName")
@@ -55,14 +55,42 @@ public final class RemoteExceptionTest {
                 .build();
         assertThat(new RemoteException(error, 500).getMessage())
                 .isEqualTo("RemoteException: errorCode (errorName) with instance ID errorId");
+    }
 
-        error = new SerializableError.Builder()
+    @Test
+    public void testUnsafeMessage_sameCodeAndName() {
+        SerializableError error = new SerializableError.Builder()
                 .errorCode("errorCode")
                 .errorName("errorCode")
                 .errorInstanceId("errorId")
                 .build();
         assertThat(new RemoteException(error, 500).getMessage())
                 .isEqualTo("RemoteException: errorCode with instance ID errorId");
+    }
+
+    @Test
+    public void testUnsafeMessage_oneParameter() {
+        SerializableError error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .errorInstanceId("errorId")
+                .putParameters("foo", "bar")
+                .build();
+        assertThat(new RemoteException(error, 500).getMessage())
+                .isEqualTo("RemoteException: errorCode (errorName) with instance ID errorId: {foo=bar}");
+    }
+
+    @Test
+    public void testUnsafeMessage_multipleParameters() {
+        SerializableError error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .errorInstanceId("errorId")
+                .putParameters("a", "b")
+                .putParameters("c", "d")
+                .build();
+        assertThat(new RemoteException(error, 500).getMessage())
+                .isEqualTo("RemoteException: errorCode (errorName) with instance ID errorId: {a=b, c=d}");
     }
 
     @Test
@@ -77,7 +105,19 @@ public final class RemoteExceptionTest {
     }
 
     @Test
-    public void testArgsIsEmpty() {
+    public void testLogMessageMessageDoesNotIncludeParameters() {
+        SerializableError error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .errorInstanceId("errorId")
+                .putParameters("param", "value")
+                .build();
+        RemoteException remoteException = new RemoteException(error, 500);
+        assertThat(remoteException.getLogMessage()).isEqualTo("RemoteException: errorCode (errorName)");
+    }
+
+    @Test
+    public void testArgsContainsOnlyErrorInstanceId() {
         RemoteException remoteException = new RemoteException(
                 new SerializableError.Builder()
                         .errorCode("errorCode")


### PR DESCRIPTION
In connected environments this makes no difference because
RemoteException.getMessage is never called, only getLogMessage.
In such cases the error instance identifier is sufficient to
search for the original failure information, however service
authors without safe-logging infrastructure are unlikely to have
access to remote instance logging and should be presented with
the failure parameters in local logging.

The message is computed lazily, very slightly reducing overhead
in environments that don't use the unsafe message, while providing
additional actionable signal to others.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
RemoteException.getMessage (unsafe message) includes SerializableError parameters. RemoteException.getLogMessage (safe) is not impacted.
==COMMIT_MSG==
