### PR TITLE
Add abstract checked exceptions

### DIFF
--- a/changelog/@unreleased/pr-634.v2.yml
+++ b/changelog/@unreleased/pr-634.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add a new abstract exception that must be caught instead. This can be extended by the generator to create checked exceptions in the server and clients.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/634

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedRemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedRemoteException.java
@@ -49,8 +49,8 @@ public abstract class CheckedRemoteException extends Exception implements SafeLo
 
     protected CheckedRemoteException(SerializableError error, int status) {
         this.stableMessage = error.errorCode().equals(error.errorName())
-                ? String.format("RemoteException: %s", error.errorCode())
-                : String.format("RemoteException: %s (%s)", error.errorCode(), error.errorName());
+                ? String.format("%s: %s", this.getClass().getSimpleName(), error.errorCode())
+                : String.format("%s: %s (%s)", this.getClass().getSimpleName(), error.errorCode(), error.errorName());
         this.message = this.stableMessage + " with instance ID " + error.errorInstanceId();
         this.error = error;
         this.status = status;

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedRemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedRemoteException.java
@@ -25,8 +25,10 @@ import java.util.List;
 /**
  * A checked exception thrown by an RPC client to indicate remote/server-side failure that should be handled by the
  * client.
+ *
+ * This is a copy of {@link RemoteException}, except it extends {@link Exception}.
  **/
-public final class CheckedRemoteException extends Exception implements SafeLoggable {
+public abstract class CheckedRemoteException extends Exception implements SafeLoggable {
     private static final long serialVersionUID = 1L;
 
     private final String message;
@@ -45,7 +47,7 @@ public final class CheckedRemoteException extends Exception implements SafeLogga
         return status;
     }
 
-    public CheckedRemoteException(SerializableError error, int status) {
+    protected CheckedRemoteException(SerializableError error, int status) {
         this.stableMessage = error.errorCode().equals(error.errorName())
                 ? String.format("RemoteException: %s", error.errorCode())
                 : String.format("RemoteException: %s (%s)", error.errorCode(), error.errorName());
@@ -56,17 +58,17 @@ public final class CheckedRemoteException extends Exception implements SafeLogga
     }
 
     @Override
-    public String getMessage() {
+    public final String getMessage() {
         return message;
     }
 
     @Override
-    public String getLogMessage() {
+    public final String getLogMessage() {
         return stableMessage;
     }
 
     @Override
-    public List<Arg<?>> getArgs() {
+    public final List<Arg<?>> getArgs() {
         // RemoteException explicitly does not support arguments because they have already been recorded
         // on the service which produced the causal SerializableError.
         return args;

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedRemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedRemoteException.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.SafeLoggable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A checked exception thrown by an RPC client to indicate remote/server-side failure that should be handled by the
+ * client.
+ **/
+public final class CheckedRemoteException extends Exception implements SafeLoggable {
+    private static final long serialVersionUID = 1L;
+
+    private final String message;
+    private final String stableMessage;
+    private final SerializableError error;
+    private final int status;
+    private final List<Arg<?>> args;
+
+    /** Returns the error thrown by a remote process which caused an RPC call to fail. */
+    public SerializableError getError() {
+        return error;
+    }
+
+    /** The HTTP status code of the HTTP response conveying the remote exception. */
+    public int getStatus() {
+        return status;
+    }
+
+    public CheckedRemoteException(SerializableError error, int status) {
+        this.stableMessage = error.errorCode().equals(error.errorName())
+                ? String.format("RemoteException: %s", error.errorCode())
+                : String.format("RemoteException: %s (%s)", error.errorCode(), error.errorName());
+        this.message = this.stableMessage + " with instance ID " + error.errorInstanceId();
+        this.error = error;
+        this.status = status;
+        this.args = Collections.singletonList(SafeArg.of("errorInstanceId", error.errorInstanceId()));
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getLogMessage() {
+        return stableMessage;
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        // RemoteException explicitly does not support arguments because they have already been recorded
+        // on the service which produced the causal SerializableError.
+        return args;
+    }
+}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  * A {@link CheckedServiceException} thrown in server-side code to indicate server-side {@link ErrorType error states}.
  * Must be explicitly caught by the clients.
  **/
-public final class CheckedServiceException extends Exception implements SafeLoggable {
+public abstract class CheckedServiceException extends Exception implements SafeLoggable {
 
     private final ErrorType errorType;
     private final List<Arg<?>> args; // unmodifiable
@@ -71,19 +71,19 @@ public final class CheckedServiceException extends Exception implements SafeLogg
     }
 
     @Override
-    public String getMessage() {
+    public final String getMessage() {
         // Including all args here since any logger not configured with safe-logging will log this message.
         return unsafeMessage;
     }
 
     @Override
-    public String getLogMessage() {
+    public final String getLogMessage() {
         // Not returning safe args here since the safe-logging framework will log this message + args explicitly.
         return noArgsMessage;
     }
 
     @Override
-    public List<Arg<?>> getArgs() {
+    public final List<Arg<?>> getArgs() {
         return args;
     }
 

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
@@ -1,0 +1,166 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link CheckedServiceException} thrown in server-side code to indicate server-side {@link ErrorType error states}.
+ * Must be explicitly caught by the clients.
+ **/
+public final class CheckedServiceException extends Exception implements SafeLoggable {
+
+    private final ErrorType errorType;
+    private final List<Arg<?>> args; // unmodifiable
+
+    private final String errorInstanceId;
+    private final String unsafeMessage;
+    private final String noArgsMessage;
+
+    /**
+     * Creates a new exception for the given error. All {@link Arg parameters} are propagated to
+     * clients; they are serialized via {@link Object#toString}.
+     */
+    public CheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
+        this(errorType, null, parameters);
+    }
+
+    /** As above, but additionally records the cause of this exception. */
+    public CheckedServiceException(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
+        // TODO(rfink): Memoize formatting?
+        super(cause);
+
+        this.errorInstanceId = generateErrorInstanceId(cause);
+        this.errorType = errorType;
+        // Note that instantiators cannot mutate List<> args since it comes through copyToList in all code paths.
+        this.args = copyToUnmodifiableList(args);
+        this.unsafeMessage = renderUnsafeMessage(errorType, args);
+        this.noArgsMessage = renderNoArgsMessage(errorType);
+    }
+
+    /** The {@link ErrorType} that gave rise to this exception. */
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+
+    /** A unique identifier for (this instance of) this error. */
+    public String getErrorInstanceId() {
+        return errorInstanceId;
+    }
+
+    @Override
+    public String getMessage() {
+        // Including all args here since any logger not configured with safe-logging will log this message.
+        return unsafeMessage;
+    }
+
+    @Override
+    public String getLogMessage() {
+        // Not returning safe args here since the safe-logging framework will log this message + args explicitly.
+        return noArgsMessage;
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return args;
+    }
+
+    /**
+     * Deprecated.
+     *
+     * @deprecated use {@link #getArgs}.
+     */
+    @Deprecated
+    public List<Arg<?>> getParameters() {
+        return getArgs();
+    }
+
+    private static <T> List<T> copyToUnmodifiableList(T[] elements) {
+        if (elements == null || elements.length == 0) {
+            return Collections.emptyList();
+        }
+        List<T> list = new ArrayList<>(elements.length);
+        for (T item : elements) {
+            if (item != null) {
+                list.add(item);
+            }
+        }
+        return Collections.unmodifiableList(list);
+    }
+
+    private static String renderUnsafeMessage(ErrorType errorType, Arg<?>... args) {
+        String message = renderNoArgsMessage(errorType);
+
+        if (args == null || args.length == 0) {
+            return message;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        boolean first = true;
+        builder.append(message).append(": {");
+        for (Arg<?> arg : args) {
+            if (arg != null) {
+                if (first) {
+                    first = false;
+                } else {
+                    builder.append(", ");
+                }
+                builder.append(arg.getName()).append("=").append(arg.getValue());
+            }
+        }
+        builder.append("}");
+
+        return builder.toString();
+    }
+
+    private static String renderNoArgsMessage(ErrorType errorType) {
+        return String.format("ServiceException: %s (%s)", errorType.code(), errorType.name());
+    }
+
+    /**
+     * Finds the errorInstanceId of the most recent cause if present, otherwise generates a new random identifier. Note
+     * that this only searches {@link Throwable#getCause() causal exceptions}, not {@link Throwable#getSuppressed()
+     * suppressed causes}.
+     */
+    private static String generateErrorInstanceId(@Nullable Throwable cause) {
+        return generateErrorInstanceId(cause, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static String generateErrorInstanceId(
+            @Nullable Throwable cause,
+            // Guard against cause cycles, see Throwable.printStackTrace(PrintStreamOrWriter)
+            Set<Throwable> dejaVu) {
+        if (cause == null || !dejaVu.add(cause)) {
+            return UUID.randomUUID().toString();
+        }
+        if (cause instanceof CheckedServiceException) {
+            return ((CheckedServiceException) cause).getErrorInstanceId();
+        }
+        if (cause instanceof RemoteException) {
+            return ((RemoteException) cause).getError().errorInstanceId();
+        }
+        return generateErrorInstanceId(cause.getCause(), dejaVu);
+    }
+}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
  *
  * This is a copy of {@link ServiceException}, except it extends {@link Exception}.
  **/
-public abstract class CheckedServiceException extends Exception implements SafeLoggable {
+public abstract class CheckedServiceException extends Exception implements SafeLoggable, TypedException {
 
     private final ErrorType errorType;
     private final List<Arg<?>> args; // unmodifiable
@@ -57,12 +57,12 @@ public abstract class CheckedServiceException extends Exception implements SafeL
         this.noArgsMessage = ServiceExceptionUtils.renderNoArgsMessage(errorType, this.getClass());
     }
 
-    /** The {@link ErrorType} that gave rise to this exception. */
+    @Override
     public ErrorType getErrorType() {
         return errorType;
     }
 
-    /** A unique identifier for (this instance of) this error. */
+    @Override
     public String getErrorInstanceId() {
         return errorInstanceId;
     }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
@@ -29,6 +29,8 @@ import javax.annotation.Nullable;
 /**
  * A {@link CheckedServiceException} thrown in server-side code to indicate server-side {@link ErrorType error states}.
  * Must be explicitly caught by the clients.
+ *
+ * This is a copy of {@link ServiceException}, except it extends {@link Exception}.
  **/
 public abstract class CheckedServiceException extends Exception implements SafeLoggable {
 
@@ -43,12 +45,12 @@ public abstract class CheckedServiceException extends Exception implements SafeL
      * Creates a new exception for the given error. All {@link Arg parameters} are propagated to
      * clients; they are serialized via {@link Object#toString}.
      */
-    public CheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
+    protected CheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
         this(errorType, null, parameters);
     }
 
     /** As above, but additionally records the cause of this exception. */
-    public CheckedServiceException(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
+    protected CheckedServiceException(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
         // TODO(rfink): Memoize formatting?
         super(cause);
 

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -44,8 +44,8 @@ public abstract class SerializableError implements Serializable {
     /**
      * A fixed code word identifying the type of error. For errors generated from {@link ServiceException}, this
      * corresponds to the {@link ErrorType#code} and is part of the service's API surface. Clients are given access to
-     * the server-side error code via {@link RemoteException#getError} and typically switch&dispatch on the error code
-     * and/or name.
+     * the server-side error code via {@link RemoteException#getError} and typically switch and dispatch on the error
+     * code and/or name.
      */
     @JsonProperty("errorCode")
     @Value.Default
@@ -58,7 +58,7 @@ public abstract class SerializableError implements Serializable {
     /**
      * A fixed name identifying the error. For errors generated from {@link ServiceException}, this corresponding to the
      * {@link ErrorType#name} and is part of the service's API surface. Clients are given access to the service-side
-     * error name via {@link RemoteException#getError} and typically switch&dispatch on the error code and/or name.
+     * error name via {@link RemoteException#getError} and typically switch and dispatch on the error code and/or name.
      */
     @JsonProperty("errorName")
     @Value.Default

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -122,6 +122,23 @@ public abstract class SerializableError implements Serializable {
         return builder.build();
     }
 
+    /**
+     * Creates a {@link SerializableError} representation of this checked exception that derives from the error code and
+     * message, as well as the {@link Arg#isSafeForLogging safe} and unsafe {@link ServiceException#args parameters}.
+     */
+    public static SerializableError forCheckedException(CheckedServiceException exception) {
+        Builder builder = new Builder()
+                .errorCode(exception.getErrorType().code().name())
+                .errorName(exception.getErrorType().name())
+                .errorInstanceId(exception.getErrorInstanceId());
+
+        for (Arg<?> arg : exception.getArgs()) {
+            builder.putParameters(arg.getName(), Objects.toString(arg.getValue()));
+        }
+
+        return builder.build();
+    }
+
     // TODO(rfink): Remove once all error producers have switched to errorCode/errorName.
     public static final class Builder extends ImmutableSerializableError.Builder {}
 

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
@@ -22,7 +22,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /** A {@link ServiceException} thrown in server-side code to indicate server-side {@link ErrorType error states}. */
-public final class ServiceException extends RuntimeException implements SafeLoggable {
+public final class ServiceException extends RuntimeException implements SafeLoggable, TypedException {
 
     private final ErrorType errorType;
     private final List<Arg<?>> args; // unmodifiable
@@ -52,12 +52,12 @@ public final class ServiceException extends RuntimeException implements SafeLogg
         this.noArgsMessage = ServiceExceptionUtils.renderNoArgsMessage(errorType, this.getClass());
     }
 
-    /** The {@link ErrorType} that gave rise to this exception. */
+    @Override
     public ErrorType getErrorType() {
         return errorType;
     }
 
-    /** A unique identifier for (this instance of) this error. */
+    @Override
     public String getErrorInstanceId() {
         return errorInstanceId;
     }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
@@ -18,12 +18,7 @@ package com.palantir.conjure.java.api.errors;
 
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeLoggable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 import javax.annotation.Nullable;
 
 /** A {@link ServiceException} thrown in server-side code to indicate server-side {@link ErrorType error states}. */
@@ -49,12 +44,12 @@ public final class ServiceException extends RuntimeException implements SafeLogg
         // TODO(rfink): Memoize formatting?
         super(cause);
 
-        this.errorInstanceId = generateErrorInstanceId(cause);
+        this.errorInstanceId = ServiceExceptionUtils.generateErrorInstanceId(cause);
         this.errorType = errorType;
         // Note that instantiators cannot mutate List<> args since it comes through copyToList in all code paths.
-        this.args = copyToUnmodifiableList(args);
-        this.unsafeMessage = renderUnsafeMessage(errorType, args);
-        this.noArgsMessage = renderNoArgsMessage(errorType);
+        this.args = ServiceExceptionUtils.copyToUnmodifiableList(args);
+        this.unsafeMessage = ServiceExceptionUtils.renderUnsafeMessage(errorType, this.getClass(), args);
+        this.noArgsMessage = ServiceExceptionUtils.renderNoArgsMessage(errorType, this.getClass());
     }
 
     /** The {@link ErrorType} that gave rise to this exception. */
@@ -92,72 +87,5 @@ public final class ServiceException extends RuntimeException implements SafeLogg
     @Deprecated
     public List<Arg<?>> getParameters() {
         return getArgs();
-    }
-
-    private static <T> List<T> copyToUnmodifiableList(T[] elements) {
-        if (elements == null || elements.length == 0) {
-            return Collections.emptyList();
-        }
-        List<T> list = new ArrayList<>(elements.length);
-        for (T item : elements) {
-            if (item != null) {
-                list.add(item);
-            }
-        }
-        return Collections.unmodifiableList(list);
-    }
-
-    private static String renderUnsafeMessage(ErrorType errorType, Arg<?>... args) {
-        String message = renderNoArgsMessage(errorType);
-
-        if (args == null || args.length == 0) {
-            return message;
-        }
-
-        StringBuilder builder = new StringBuilder();
-        boolean first = true;
-        builder.append(message).append(": {");
-        for (Arg<?> arg : args) {
-            if (arg != null) {
-                if (first) {
-                    first = false;
-                } else {
-                    builder.append(", ");
-                }
-                builder.append(arg.getName()).append("=").append(arg.getValue());
-            }
-        }
-        builder.append("}");
-
-        return builder.toString();
-    }
-
-    private static String renderNoArgsMessage(ErrorType errorType) {
-        return String.format("ServiceException: %s (%s)", errorType.code(), errorType.name());
-    }
-
-    /**
-     * Finds the errorInstanceId of the most recent cause if present, otherwise generates a new random identifier. Note
-     * that this only searches {@link Throwable#getCause() causal exceptions}, not {@link Throwable#getSuppressed()
-     * suppressed causes}.
-     */
-    private static String generateErrorInstanceId(@Nullable Throwable cause) {
-        return generateErrorInstanceId(cause, Collections.newSetFromMap(new IdentityHashMap<>()));
-    }
-
-    private static String generateErrorInstanceId(
-            @Nullable Throwable cause,
-            // Guard against cause cycles, see Throwable.printStackTrace(PrintStreamOrWriter)
-            Set<Throwable> dejaVu) {
-        if (cause == null || !dejaVu.add(cause)) {
-            return UUID.randomUUID().toString();
-        }
-        if (cause instanceof ServiceException) {
-            return ((ServiceException) cause).getErrorInstanceId();
-        }
-        if (cause instanceof RemoteException) {
-            return ((RemoteException) cause).getError().errorInstanceId();
-        }
-        return generateErrorInstanceId(cause.getCause(), dejaVu);
     }
 }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceExceptionUtils.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceExceptionUtils.java
@@ -1,0 +1,103 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.logsafe.Arg;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+final class ServiceExceptionUtils {
+    private ServiceExceptionUtils() {}
+
+    static <T> List<T> copyToUnmodifiableList(T[] elements) {
+        if (elements == null || elements.length == 0) {
+            return Collections.emptyList();
+        }
+        List<T> list = new ArrayList<>(elements.length);
+        for (T item : elements) {
+            if (item != null) {
+                list.add(item);
+            }
+        }
+        return Collections.unmodifiableList(list);
+    }
+
+    static String renderUnsafeMessage(ErrorType errorType, Class<?> clazz, Arg<?>... args) {
+        String message = renderNoArgsMessage(errorType, clazz);
+
+        if (args == null || args.length == 0) {
+            return message;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        boolean first = true;
+        builder.append(message).append(": {");
+        for (Arg<?> arg : args) {
+            if (arg != null) {
+                if (first) {
+                    first = false;
+                } else {
+                    builder.append(", ");
+                }
+                builder.append(arg.getName()).append("=").append(arg.getValue());
+            }
+        }
+        builder.append("}");
+
+        return builder.toString();
+    }
+
+    static String renderNoArgsMessage(ErrorType errorType, Class<?> clazz) {
+        return String.format("%s: %s (%s)", clazz.getSimpleName(), errorType.code(), errorType.name());
+    }
+
+    /**
+     * Finds the errorInstanceId of the most recent cause if present, otherwise generates a new random identifier. Note
+     * that this only searches {@link Throwable#getCause() causal exceptions}, not {@link Throwable#getSuppressed()
+     * suppressed causes}.
+     */
+    static String generateErrorInstanceId(@Nullable Throwable cause) {
+        return generateErrorInstanceId(cause, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    static String generateErrorInstanceId(
+            @Nullable Throwable cause,
+            // Guard against cause cycles, see Throwable.printStackTrace(PrintStreamOrWriter)
+            Set<Throwable> dejaVu) {
+        if (cause == null || !dejaVu.add(cause)) {
+            return UUID.randomUUID().toString();
+        }
+        if (cause instanceof ServiceException) {
+            return ((ServiceException) cause).getErrorInstanceId();
+        }
+        if (cause instanceof RemoteException) {
+            return ((RemoteException) cause).getError().errorInstanceId();
+        }
+        if (cause instanceof CheckedServiceException) {
+            return ((CheckedServiceException) cause).getErrorInstanceId();
+        }
+        if (cause instanceof CheckedRemoteException) {
+            return ((CheckedRemoteException) cause).getError().errorInstanceId();
+        }
+        return generateErrorInstanceId(cause.getCause(), dejaVu);
+    }
+}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/TypedException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/TypedException.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+public interface TypedException {
+    /** The {@link ErrorType} that gave rise to this exception. */
+    ErrorType getErrorType();
+
+    /** A unique identifier for (this instance of) this error. */
+    String getErrorInstanceId();
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedRemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedRemoteExceptionTest.java
@@ -1,0 +1,97 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.logsafe.SafeArg;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.jupiter.api.Test;
+
+public final class CheckedRemoteExceptionTest {
+
+    private static class CheckedRemoteExceptionImpl extends CheckedRemoteException {
+        protected CheckedRemoteExceptionImpl(SerializableError error, int status) {
+            super(error, status);
+        }
+    }
+
+    @Test
+    public void testJavaSerialization() {
+        // With explicit error instance
+        SerializableError error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .errorInstanceId("errorId")
+                .build();
+        CheckedRemoteExceptionImpl expected = new CheckedRemoteExceptionImpl(error, 500);
+        CheckedRemoteExceptionImpl actual = SerializationUtils.deserialize(SerializationUtils.serialize(expected));
+        assertThat(actual).isEqualToComparingFieldByField(expected);
+
+        // Without error instance
+        error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .build();
+        expected = new CheckedRemoteExceptionImpl(error, 500);
+        actual = SerializationUtils.deserialize(SerializationUtils.serialize(expected));
+        assertThat(actual).isEqualToComparingFieldByField(expected);
+    }
+
+    @Test
+    public void testSuperMessage() {
+        SerializableError error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .errorInstanceId("errorId")
+                .build();
+        assertThat(new CheckedRemoteExceptionImpl(error, 500).getMessage())
+                .isEqualTo("CheckedRemoteExceptionImpl: errorCode (errorName) with instance ID errorId");
+
+        error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorCode")
+                .errorInstanceId("errorId")
+                .build();
+        assertThat(new CheckedRemoteExceptionImpl(error, 500).getMessage())
+                .isEqualTo("CheckedRemoteExceptionImpl: errorCode with instance ID errorId");
+    }
+
+    @Test
+    public void testLogMessageMessage() {
+        SerializableError error = new SerializableError.Builder()
+                .errorCode("errorCode")
+                .errorName("errorName")
+                .errorInstanceId("errorId")
+                .build();
+        CheckedRemoteExceptionImpl remoteException = new CheckedRemoteExceptionImpl(error, 500);
+        assertThat(remoteException.getLogMessage()).isEqualTo("CheckedRemoteExceptionImpl: errorCode (errorName)");
+    }
+
+    @Test
+    public void testArgsIsEmpty() {
+        CheckedRemoteExceptionImpl remoteException = new CheckedRemoteExceptionImpl(
+                new SerializableError.Builder()
+                        .errorCode("errorCode")
+                        .errorName("errorName")
+                        .errorInstanceId("errorId")
+                        .putParameters("param", "value")
+                        .build(),
+                500);
+        assertThat(remoteException.getArgs()).containsExactly(SafeArg.of("errorInstanceId", "errorId"));
+    }
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedRemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedRemoteExceptionTest.java
@@ -24,12 +24,6 @@ import org.junit.jupiter.api.Test;
 
 public final class CheckedRemoteExceptionTest {
 
-    private static class CheckedRemoteExceptionImpl extends CheckedRemoteException {
-        protected CheckedRemoteExceptionImpl(SerializableError error, int status) {
-            super(error, status);
-        }
-    }
-
     @Test
     public void testJavaSerialization() {
         // With explicit error instance
@@ -38,8 +32,8 @@ public final class CheckedRemoteExceptionTest {
                 .errorName("errorName")
                 .errorInstanceId("errorId")
                 .build();
-        CheckedRemoteExceptionImpl expected = new CheckedRemoteExceptionImpl(error, 500);
-        CheckedRemoteExceptionImpl actual = SerializationUtils.deserialize(SerializationUtils.serialize(expected));
+        ExampleCheckedRemoteException expected = new ExampleCheckedRemoteException(error, 500);
+        ExampleCheckedRemoteException actual = SerializationUtils.deserialize(SerializationUtils.serialize(expected));
         assertThat(actual).isEqualToComparingFieldByField(expected);
 
         // Without error instance
@@ -47,7 +41,7 @@ public final class CheckedRemoteExceptionTest {
                 .errorCode("errorCode")
                 .errorName("errorName")
                 .build();
-        expected = new CheckedRemoteExceptionImpl(error, 500);
+        expected = new ExampleCheckedRemoteException(error, 500);
         actual = SerializationUtils.deserialize(SerializationUtils.serialize(expected));
         assertThat(actual).isEqualToComparingFieldByField(expected);
     }
@@ -59,16 +53,16 @@ public final class CheckedRemoteExceptionTest {
                 .errorName("errorName")
                 .errorInstanceId("errorId")
                 .build();
-        assertThat(new CheckedRemoteExceptionImpl(error, 500).getMessage())
-                .isEqualTo("CheckedRemoteExceptionImpl: errorCode (errorName) with instance ID errorId");
+        assertThat(new ExampleCheckedRemoteException(error, 500).getMessage())
+                .isEqualTo("ExampleCheckedRemoteException: errorCode (errorName) with instance ID errorId");
 
         error = new SerializableError.Builder()
                 .errorCode("errorCode")
                 .errorName("errorCode")
                 .errorInstanceId("errorId")
                 .build();
-        assertThat(new CheckedRemoteExceptionImpl(error, 500).getMessage())
-                .isEqualTo("CheckedRemoteExceptionImpl: errorCode with instance ID errorId");
+        assertThat(new ExampleCheckedRemoteException(error, 500).getMessage())
+                .isEqualTo("ExampleCheckedRemoteException: errorCode with instance ID errorId");
     }
 
     @Test
@@ -78,13 +72,13 @@ public final class CheckedRemoteExceptionTest {
                 .errorName("errorName")
                 .errorInstanceId("errorId")
                 .build();
-        CheckedRemoteExceptionImpl remoteException = new CheckedRemoteExceptionImpl(error, 500);
-        assertThat(remoteException.getLogMessage()).isEqualTo("CheckedRemoteExceptionImpl: errorCode (errorName)");
+        ExampleCheckedRemoteException remoteException = new ExampleCheckedRemoteException(error, 500);
+        assertThat(remoteException.getLogMessage()).isEqualTo("ExampleCheckedRemoteException: errorCode (errorName)");
     }
 
     @Test
     public void testArgsIsEmpty() {
-        CheckedRemoteExceptionImpl remoteException = new CheckedRemoteExceptionImpl(
+        ExampleCheckedRemoteException remoteException = new ExampleCheckedRemoteException(
                 new SerializableError.Builder()
                         .errorCode("errorCode")
                         .errorName("errorName")

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
@@ -1,0 +1,138 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+public final class CheckedServiceExceptionTest {
+
+    private static final String ERROR_NAME = "Namespace:MyDesc";
+    private static final ErrorType ERROR = ErrorType.create(ErrorType.Code.CUSTOM_CLIENT, ERROR_NAME);
+    private static final String EXPECTED_ERROR_MSG =
+            "CheckedServiceExceptionImpl: " + "CUSTOM_CLIENT (Namespace:MyDesc)";
+
+    private static class CheckedServiceExceptionImpl extends CheckedServiceException {
+        protected CheckedServiceExceptionImpl(ErrorType errorType, Arg<?>... parameters) {
+            super(errorType, parameters);
+        }
+
+        protected CheckedServiceExceptionImpl(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
+            super(errorType, cause, args);
+        }
+    }
+
+    @Test
+    public void testExceptionMessageContainsNoArgs_safeLogMessageContainsSafeArgsOnly() {
+        Arg<?>[] args = {SafeArg.of("arg1", "foo"), UnsafeArg.of("arg2", 2), UnsafeArg.of("arg3", null)};
+        CheckedServiceException ex = new CheckedServiceExceptionImpl(ERROR, args);
+
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg2=2, arg3=null}");
+    }
+
+    @Test
+    public void testExceptionMessageWithDuplicateKeys() {
+        CheckedServiceException ex =
+                new CheckedServiceExceptionImpl(ERROR, SafeArg.of("arg1", "foo"), SafeArg.of("arg1", 2));
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg1=2}");
+    }
+
+    @Test
+    public void testExceptionMessageWithUnsafeArgs() {
+        CheckedServiceExceptionImpl ex =
+                new CheckedServiceExceptionImpl(ERROR, UnsafeArg.of("arg1", 1), SafeArg.of("arg2", 2));
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
+    }
+
+    @Test
+    public void testExceptionMessageWithNullArg() {
+        CheckedServiceExceptionImpl ex =
+                new CheckedServiceExceptionImpl(ERROR, UnsafeArg.of("arg1", 1), null, SafeArg.of("arg2", 2));
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
+        assertThat(ex.getArgs()).doesNotContainNull().hasSize(2);
+    }
+
+    @Test
+    public void testExceptionMessageWithNoArgs() {
+        CheckedServiceExceptionImpl ex = new CheckedServiceExceptionImpl(ERROR);
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+    }
+
+    @Test
+    public void testExceptionCause() {
+        Throwable cause = new RuntimeException("foo");
+        CheckedServiceExceptionImpl ex = new CheckedServiceExceptionImpl(ERROR, cause);
+
+        assertThat(ex.getCause()).isEqualTo(cause);
+    }
+
+    @Test
+    public void testStatus() {
+        CheckedServiceExceptionImpl ex = new CheckedServiceExceptionImpl(ERROR);
+        assertThat(ex.getErrorType().httpErrorCode()).isEqualTo(400);
+    }
+
+    @Test
+    public void testErrorIdsAreUnique() {
+        UUID errorId1 = UUID.fromString(new CheckedServiceExceptionImpl(ERROR).getErrorInstanceId());
+        UUID errorId2 = UUID.fromString(new CheckedServiceExceptionImpl(ERROR).getErrorInstanceId());
+
+        assertThat(errorId1).isNotEqualTo(errorId2);
+    }
+
+    @Test
+    public void testErrorIdsAreInheritedFromCheckedServiceExceptionImpls() {
+        CheckedServiceExceptionImpl rootCause = new CheckedServiceExceptionImpl(ERROR);
+        SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
+        CheckedServiceExceptionImpl parent = new CheckedServiceExceptionImpl(ERROR, intermediate);
+        assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getErrorInstanceId());
+    }
+
+    @Test
+    public void testErrorIdsAreInheritedFromRemoteExceptions() {
+        RemoteException rootCause = new RemoteException(
+                new SerializableError.Builder()
+                        .errorCode("errorCode")
+                        .errorName("errorName")
+                        .build(),
+                500);
+        SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
+        CheckedServiceExceptionImpl parent = new CheckedServiceExceptionImpl(ERROR, intermediate);
+        assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getError().errorInstanceId());
+    }
+
+    @Test
+    public void testCircularCause() {
+        RuntimeException first = new RuntimeException();
+        RuntimeException second = new RuntimeException(first);
+        // Yes, you can do this. In practice it's often more subtle when libraries attempt to piece together
+        // more helpful exception chains and encounter unexpected edge cases.
+        first.initCause(second);
+        // invoke getErrorInstanceId to ensure this is tested even if future developers
+        // optimize generation to occur lazily.
+        assertThat(new CheckedServiceExceptionImpl(ERROR, second).getErrorInstanceId())
+                .isNotNull();
+    }
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
@@ -23,7 +23,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.util.UUID;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 public final class CheckedServiceExceptionTest {
@@ -31,22 +30,12 @@ public final class CheckedServiceExceptionTest {
     private static final String ERROR_NAME = "Namespace:MyDesc";
     private static final ErrorType ERROR = ErrorType.create(ErrorType.Code.CUSTOM_CLIENT, ERROR_NAME);
     private static final String EXPECTED_ERROR_MSG =
-            "CheckedServiceExceptionImpl: " + "CUSTOM_CLIENT (Namespace:MyDesc)";
-
-    private static class CheckedServiceExceptionImpl extends CheckedServiceException {
-        protected CheckedServiceExceptionImpl(ErrorType errorType, Arg<?>... parameters) {
-            super(errorType, parameters);
-        }
-
-        protected CheckedServiceExceptionImpl(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
-            super(errorType, cause, args);
-        }
-    }
+            "ExampleCheckedServiceException: " + "CUSTOM_CLIENT (Namespace:MyDesc)";
 
     @Test
     public void testExceptionMessageContainsNoArgs_safeLogMessageContainsSafeArgsOnly() {
         Arg<?>[] args = {SafeArg.of("arg1", "foo"), UnsafeArg.of("arg2", 2), UnsafeArg.of("arg3", null)};
-        CheckedServiceException ex = new CheckedServiceExceptionImpl(ERROR, args);
+        CheckedServiceException ex = new ExampleCheckedServiceException(ERROR, args);
 
         assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg2=2, arg3=null}");
@@ -55,58 +44,58 @@ public final class CheckedServiceExceptionTest {
     @Test
     public void testExceptionMessageWithDuplicateKeys() {
         CheckedServiceException ex =
-                new CheckedServiceExceptionImpl(ERROR, SafeArg.of("arg1", "foo"), SafeArg.of("arg1", 2));
+                new ExampleCheckedServiceException(ERROR, SafeArg.of("arg1", "foo"), SafeArg.of("arg1", 2));
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg1=2}");
     }
 
     @Test
     public void testExceptionMessageWithUnsafeArgs() {
-        CheckedServiceExceptionImpl ex =
-                new CheckedServiceExceptionImpl(ERROR, UnsafeArg.of("arg1", 1), SafeArg.of("arg2", 2));
+        ExampleCheckedServiceException ex =
+                new ExampleCheckedServiceException(ERROR, UnsafeArg.of("arg1", 1), SafeArg.of("arg2", 2));
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
     }
 
     @Test
     public void testExceptionMessageWithNullArg() {
-        CheckedServiceExceptionImpl ex =
-                new CheckedServiceExceptionImpl(ERROR, UnsafeArg.of("arg1", 1), null, SafeArg.of("arg2", 2));
+        ExampleCheckedServiceException ex =
+                new ExampleCheckedServiceException(ERROR, UnsafeArg.of("arg1", 1), null, SafeArg.of("arg2", 2));
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
         assertThat(ex.getArgs()).doesNotContainNull().hasSize(2);
     }
 
     @Test
     public void testExceptionMessageWithNoArgs() {
-        CheckedServiceExceptionImpl ex = new CheckedServiceExceptionImpl(ERROR);
+        ExampleCheckedServiceException ex = new ExampleCheckedServiceException(ERROR);
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG);
     }
 
     @Test
     public void testExceptionCause() {
         Throwable cause = new RuntimeException("foo");
-        CheckedServiceExceptionImpl ex = new CheckedServiceExceptionImpl(ERROR, cause);
+        ExampleCheckedServiceException ex = new ExampleCheckedServiceException(ERROR, cause);
 
         assertThat(ex.getCause()).isEqualTo(cause);
     }
 
     @Test
     public void testStatus() {
-        CheckedServiceExceptionImpl ex = new CheckedServiceExceptionImpl(ERROR);
+        ExampleCheckedServiceException ex = new ExampleCheckedServiceException(ERROR);
         assertThat(ex.getErrorType().httpErrorCode()).isEqualTo(400);
     }
 
     @Test
     public void testErrorIdsAreUnique() {
-        UUID errorId1 = UUID.fromString(new CheckedServiceExceptionImpl(ERROR).getErrorInstanceId());
-        UUID errorId2 = UUID.fromString(new CheckedServiceExceptionImpl(ERROR).getErrorInstanceId());
+        UUID errorId1 = UUID.fromString(new ExampleCheckedServiceException(ERROR).getErrorInstanceId());
+        UUID errorId2 = UUID.fromString(new ExampleCheckedServiceException(ERROR).getErrorInstanceId());
 
         assertThat(errorId1).isNotEqualTo(errorId2);
     }
 
     @Test
-    public void testErrorIdsAreInheritedFromCheckedServiceExceptionImpls() {
-        CheckedServiceExceptionImpl rootCause = new CheckedServiceExceptionImpl(ERROR);
+    public void testErrorIdsAreInheritedFromExampleCheckedServiceExceptions() {
+        ExampleCheckedServiceException rootCause = new ExampleCheckedServiceException(ERROR);
         SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
-        CheckedServiceExceptionImpl parent = new CheckedServiceExceptionImpl(ERROR, intermediate);
+        ExampleCheckedServiceException parent = new ExampleCheckedServiceException(ERROR, intermediate);
         assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getErrorInstanceId());
     }
 
@@ -119,7 +108,7 @@ public final class CheckedServiceExceptionTest {
                         .build(),
                 500);
         SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
-        CheckedServiceExceptionImpl parent = new CheckedServiceExceptionImpl(ERROR, intermediate);
+        ExampleCheckedServiceException parent = new ExampleCheckedServiceException(ERROR, intermediate);
         assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getError().errorInstanceId());
     }
 
@@ -132,7 +121,7 @@ public final class CheckedServiceExceptionTest {
         first.initCause(second);
         // invoke getErrorInstanceId to ensure this is tested even if future developers
         // optimize generation to occur lazily.
-        assertThat(new CheckedServiceExceptionImpl(ERROR, second).getErrorInstanceId())
+        assertThat(new ExampleCheckedServiceException(ERROR, second).getErrorInstanceId())
                 .isNotNull();
     }
 }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ExampleCheckedRemoteException.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ExampleCheckedRemoteException.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+public class ExampleCheckedRemoteException extends CheckedRemoteException {
+    protected ExampleCheckedRemoteException(SerializableError error, int status) {
+        super(error, status);
+    }
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ExampleCheckedServiceException.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ExampleCheckedServiceException.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.logsafe.Arg;
+import javax.annotation.Nullable;
+
+public class ExampleCheckedServiceException extends CheckedServiceException {
+    protected ExampleCheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
+        super(errorType, parameters);
+    }
+
+    protected ExampleCheckedServiceException(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
+        super(errorType, cause, args);
+    }
+}
+

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
@@ -66,6 +66,37 @@ public final class SerializableErrorTest {
     }
 
     @Test
+    public void forCheckedException_should_keep_both_safe_and_unsafe_args() {
+        ErrorType error = ErrorType.FAILED_PRECONDITION;
+        CheckedServiceException exception = new ExampleCheckedServiceException(
+                error, SafeArg.of("safeKey", 42), UnsafeArg.of("sensitiveInfo", "some user-entered content"));
+
+        SerializableError expected = new SerializableError.Builder()
+                .errorCode(error.code().name())
+                .errorName(error.name())
+                .errorInstanceId(exception.getErrorInstanceId())
+                .putParameters("safeKey", "42")
+                .putParameters("sensitiveInfo", "some user-entered content")
+                .build();
+        assertThat(SerializableError.forCheckedException(exception)).isEqualTo(expected);
+    }
+
+    @Test
+    public void forCheckedException_arg_key_collisions_just_use_the_last_one() {
+        ErrorType error = ErrorType.INTERNAL;
+        CheckedServiceException exception = new ExampleCheckedServiceException(
+                error, SafeArg.of("collision", "first"), UnsafeArg.of("collision", "second"));
+
+        SerializableError expected = new SerializableError.Builder()
+                .errorCode(error.code().name())
+                .errorName(error.name())
+                .errorInstanceId(exception.getErrorInstanceId())
+                .putParameters("collision", "second")
+                .build();
+        assertThat(SerializableError.forCheckedException(exception)).isEqualTo(expected);
+    }
+
+    @Test
     public void testSerializationContainsRedundantParameters() throws Exception {
         assertThat(mapper.writeValueAsString(ERROR))
                 .isEqualTo("{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
@@ -79,4 +79,15 @@ public final class AssertionsTest {
                 })
                 .isGeneratedFromErrorType(ErrorType.INTERNAL);
     }
+
+    @Test
+    public void testAssertThatRemoteExceptionThrownBy_catchesCheckedServiceException() {
+        assertThatRemoteExceptionThrownBy(() -> {
+                    throw new RemoteException(
+                            SerializableError.forCheckedException(
+                                    new ExampleCheckedServiceException(ErrorType.INTERNAL)),
+                            ErrorType.INTERNAL.httpErrorCode());
+                })
+                .isGeneratedFromErrorType(ErrorType.INTERNAL);
+    }
 }

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ExampleCheckedRemoteException.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ExampleCheckedRemoteException.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.testing;
+
+import com.palantir.conjure.java.api.errors.CheckedRemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
+
+public class ExampleCheckedRemoteException extends CheckedRemoteException {
+    protected ExampleCheckedRemoteException(SerializableError error, int status) {
+        super(error, status);
+    }
+}

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ExampleCheckedServiceException.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ExampleCheckedServiceException.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.testing;
+
+import com.palantir.conjure.java.api.errors.CheckedServiceException;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.logsafe.Arg;
+import javax.annotation.Nullable;
+
+public class ExampleCheckedServiceException extends CheckedServiceException {
+    protected ExampleCheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
+        super(errorType, parameters);
+    }
+
+    protected ExampleCheckedServiceException(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
+        super(errorType, cause, args);
+    }
+}


### PR DESCRIPTION
**This PR is step 2. Step 1 is here: https://github.com/palantir/conjure/pull/816**

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
All exception types are runtime, and thus do not mandate that they should be handled by the developer.
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add a new abstract exception that must be caught instead. This can be extended by the generator to create checked exceptions in the server and clients.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

