### PR TITLE
RemoteException emits more safeargs

### DIFF
--- a/changelog/@unreleased/pr-655.v2.yml
+++ b/changelog/@unreleased/pr-655.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: RemoteExceptions now emit SafeArgs for `errorInstanceId`, `errorCode` and `errorName` (previously it was just `errorInstanceId`)
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/655

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -19,12 +19,16 @@ package com.palantir.conjure.java.api.errors;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 /** An exception thrown by an RPC client to indicate remote/server-side failure. */
 public final class RemoteException extends RuntimeException implements SafeLoggable {
     private static final long serialVersionUID = 1L;
+    private static final String ERROR_INSTANCE_ID = "errorInstanceId";
+    private static final String ERROR_CODE = "errorCode";
+    private static final String ERROR_NAME = "errorName";
 
     private final String message;
     private final String stableMessage;
@@ -49,7 +53,10 @@ public final class RemoteException extends RuntimeException implements SafeLogga
         this.message = this.stableMessage + " with instance ID " + error.errorInstanceId();
         this.error = error;
         this.status = status;
-        this.args = Collections.singletonList(SafeArg.of("errorInstanceId", error.errorInstanceId()));
+        this.args = Collections.unmodifiableList(Arrays.asList(
+                SafeArg.of(ERROR_INSTANCE_ID, error.errorInstanceId()),
+                SafeArg.of(ERROR_NAME, error.errorName()),
+                SafeArg.of(ERROR_CODE, error.errorCode())));
     }
 
     @Override

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
@@ -86,6 +86,10 @@ public final class RemoteExceptionTest {
                         .putParameters("param", "value")
                         .build(),
                 500);
-        assertThat(remoteException.getArgs()).containsExactly(SafeArg.of("errorInstanceId", "errorId"));
+        assertThat(remoteException.getArgs())
+                .containsExactlyInAnyOrder(
+                        SafeArg.of("errorInstanceId", "errorId"),
+                        SafeArg.of("errorCode", "errorCode"),
+                        SafeArg.of("errorName", "errorName"));
     }
 }


### PR DESCRIPTION
## Before this PR

Context in #dev-rpc - BLUF is that logs in aries are hard to filter when there are many RemoteExceptions, but they have different causes.

## After this PR
==COMMIT_MSG==
RemoteExceptions now emit SafeArgs for `errorInstanceId`, `errorCode` and `errorName` (previously it was just `errorInstanceId`)
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

