### PR TITLE
Clarify UnknownRemoteException message

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
@@ -42,7 +42,7 @@ public final class UnknownRemoteException extends RuntimeException implements Sa
     }
 
     public UnknownRemoteException(int status, String body) {
-        super(String.format("UnknownRemoteException: %s", status));
+        super(String.format("Response status: %s", status));
         this.status = status;
         this.body = body;
     }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
@@ -42,14 +42,14 @@ public final class UnknownRemoteException extends RuntimeException implements Sa
     }
 
     public UnknownRemoteException(int status, String body) {
-        super(String.format("Error %s. (Failed to parse response body as SerializableError.)", status));
+        super(String.format("UnknownRemoteException: %s", status));
         this.status = status;
         this.body = body;
     }
 
     @Override
     public String getLogMessage() {
-        return "Failed to parse response body as SerializableError.";
+        return getMessage();
     }
 
     @Override

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/UnknownRemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/UnknownRemoteExceptionTest.java
@@ -27,8 +27,8 @@ class UnknownRemoteExceptionTest {
     @Test
     public void testMessage() {
         UnknownRemoteException exception = new UnknownRemoteException(404, "not found");
-        assertThat(exception.getMessage()).isEqualTo("UnknownRemoteException: 404");
-        assertThat(exception.getLogMessage()).isEqualTo("UnknownRemoteException: 404");
+        assertThat(exception.getMessage()).isEqualTo("Response status: 404");
+        assertThat(exception.getLogMessage()).isEqualTo("Response status: 404");
     }
 
     @Test

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/UnknownRemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/UnknownRemoteExceptionTest.java
@@ -27,9 +27,8 @@ class UnknownRemoteExceptionTest {
     @Test
     public void testMessage() {
         UnknownRemoteException exception = new UnknownRemoteException(404, "not found");
-        assertThat(exception.getMessage())
-                .isEqualTo("Error 404. (Failed to parse response body as SerializableError.)");
-        assertThat(exception.getLogMessage()).isEqualTo("Failed to parse response body as SerializableError.");
+        assertThat(exception.getMessage()).isEqualTo("UnknownRemoteException: 404");
+        assertThat(exception.getLogMessage()).isEqualTo("UnknownRemoteException: 404");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
The `UnknownRemoteException` error message can be misleading. Dialogue uses `UnknownRemoteException` for things other than just failing to deserialize a `SerializableError`.

## After this PR
The `UnknownRemoteException` error message has been made a bit more generic to avoid being misleading.