### PR TITLE
Add SOCKS proxy support to the API

### DIFF
--- a/changelog/@unreleased/pr-699.v2.yml
+++ b/changelog/@unreleased/pr-699.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add SOCKS proxy support to the API
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/699

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -56,7 +56,10 @@ public abstract class ProxyConfiguration {
          * Redirects requests to the {@link #hostAndPort} and sets the HTTP Host header to the original request's
          * authority.
          */
-        MESH
+        MESH,
+
+        /** Connections are created using a SOCKS proxy. */
+        SOCKS,
     }
 
     /**
@@ -95,12 +98,22 @@ public abstract class ProxyConfiguration {
                 break;
             case DIRECT:
                 Preconditions.checkArgument(
-                        !hostAndPort().isPresent() && !credentials().isPresent(),
+                        hostAndPort().isEmpty() && credentials().isEmpty(),
                         "Neither credential nor host-and-port may be configured for DIRECT proxies");
                 break;
             case FROM_ENVIRONMENT:
                 Preconditions.checkArgument(
-                        !hostAndPort().isPresent(), "Host-and-port may not be configured for FROM_ENVIRONMENT proxies");
+                        hostAndPort().isEmpty(), "Host-and-port may not be configured for FROM_ENVIRONMENT proxies");
+                break;
+            case SOCKS:
+                Preconditions.checkArgument(
+                        hostAndPort().isPresent(), "host-and-port must be configured for a SOCKS proxy");
+                HostAndPort socksHostAndPort =
+                        HostAndPort.fromString(hostAndPort().get());
+                Preconditions.checkArgument(
+                        socksHostAndPort.hasPort(),
+                        "Given hostname does not contain a port number",
+                        SafeArg.of("hostname", socksHostAndPort));
                 break;
             default:
                 throw new SafeIllegalStateException("Unrecognized case; this is a library bug");

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -136,6 +136,10 @@ public abstract class ProxyConfiguration {
         return builder().type(Type.MESH).hostAndPort(hostAndPort).build();
     }
 
+    public static ProxyConfiguration socks(String hostAndPort) {
+        return builder().type(Type.SOCKS).hostAndPort(hostAndPort).build();
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
@@ -101,15 +101,30 @@ public final class ProxyConfigurationTests {
     }
 
     @Test
-    public void credentialsWithNonHttp() {
+    public void credentialsWithDirectProxy() {
         assertThatThrownBy(() -> ProxyConfiguration.builder()
                         .credentials(BasicCredentials.of("foo", "bar"))
                         .type(ProxyConfiguration.Type.DIRECT)
                         .build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Neither credential nor host-and-port may be configured for DIRECT proxies");
+    }
+
+    @Test
+    public void credentialsWithMeshProxy() {
         assertThatThrownBy(() -> ProxyConfiguration.builder()
                         .type(ProxyConfiguration.Type.MESH)
+                        .credentials(BasicCredentials.of("foo", "bar"))
+                        .hostAndPort("localhost:1234")
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("credentials only valid for HTTP proxies");
+    }
+
+    @Test
+    public void credentialsWithSocksProxy() {
+        assertThatThrownBy(() -> ProxyConfiguration.builder()
+                        .type(ProxyConfiguration.Type.SOCKS)
                         .credentials(BasicCredentials.of("foo", "bar"))
                         .hostAndPort("localhost:1234")
                         .build())


### PR DESCRIPTION
==COMMIT_MSG==
Add SOCKS proxy support to the API
==COMMIT_MSG==

## Possible downsides?
more proxies, socks is very hard to unit test

