### PR TITLE
Construct RemoteException from ServiceException

### DIFF
--- a/changelog/@unreleased/pr-710.v2.yml
+++ b/changelog/@unreleased/pr-710.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: A RemoteException can now be constructed directly from a ServiceException,
+    rather than requiring a SerializableError. This is designed to allow constructing
+    RemoteExceptions from other service's generated ServiceExceptions for testing.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/710

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -59,6 +59,12 @@ public final class RemoteException extends RuntimeException implements SafeLogga
                 SafeArg.of(ERROR_CODE, error.errorCode())));
     }
 
+    public RemoteException(ServiceException serviceException) {
+        this(
+                SerializableError.forException(serviceException),
+                serviceException.getErrorType().httpErrorCode());
+    }
+
     @Override
     public String getMessage() {
         return message;

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/RemoteExceptionTest.java
@@ -47,6 +47,15 @@ public final class RemoteExceptionTest {
     }
 
     @Test
+    public void testFromServiceException() {
+        ServiceException serviceException =
+                new ServiceException(ErrorType.INTERNAL, SafeArg.of("safeArg", "safeValue"));
+        RemoteException expected = new RemoteException(SerializableError.forException(serviceException), 500);
+        RemoteException actual = new RemoteException(serviceException);
+        assertThat(actual).isEqualToComparingFieldByField(expected);
+    }
+
+    @Test
     public void testSuperMessage() {
         SerializableError error = new SerializableError.Builder()
                 .errorCode("errorCode")


### PR DESCRIPTION
## Before this PR

When testing how my code handles RemoteExceptions from other services, I often construct RemoteExceptions from other services' published Conjure ServiceExceptions. I always end up writing the same little utility class to serialize the ServiceException, get its error code, and use that to create a RemoteException.

## After this PR

==COMMIT_MSG==
Construct RemoteException from ServiceException
==COMMIT_MSG==