### PR TITLE
Test against Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,12 @@ plugins {
 apply plugin: 'com.palantir.external-publish'
 apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.consistent-versions'
+apply plugin: 'com.palantir.baseline-java-versions'
+
+javaVersions {
+    libraryTarget = 11
+    runtime = 17
+}
 
 allprojects {
     apply plugin: 'com.palantir.java-format'
@@ -36,7 +42,6 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'com.palantir.baseline-class-uniqueness'
 
-    sourceCompatibility = 1.8
     tasks.check.dependsOn(javadoc)
 
     test {


### PR DESCRIPTION
Note that this increases the source and bytecode compatibility
from Java 8 to Java 11. This is not considered a break because
the SafeLogger dependency already requires java 11, so there is
no change in runtime requirements.

==COMMIT_MSG==
Test against Java 17
==COMMIT_MSG==

