### PR TITLE
Add RemoteException.isOfType(ErrorType) convenience method

### DIFF
--- a/changelog/@unreleased/pr-867.v2.yml
+++ b/changelog/@unreleased/pr-867.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add RemoteException.isOfType(ErrorType) convenience method.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/867

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -100,4 +100,8 @@ public final class RemoteException extends RuntimeException implements SafeLogga
         // on the service which produced the causal SerializableError.
         return args;
     }
+
+    public boolean isOfType(ErrorType type) {
+        return error.errorName().equals(type.name()) && status == type.httpErrorCode();
+    }
 }


### PR DESCRIPTION
## Before this PR
Checking whether a RemoteException is of a particular type is verbose.

## After this PR
Simply do `exception.isOfType(MyErrorTypes.SPECIFIC_ERROR)`
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add RemoteException.isOfType(ErrorType) convenience method.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

