### PR TITLE
Optimize UserAgents

### DIFF
--- a/changelog/@unreleased/pr-868.v2.yml
+++ b/changelog/@unreleased/pr-868.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: |-
+    Optimize UserAgents
+
+    Optimize UserAgents.isValidName to use a hand-rolled implementation to validate user agent name to avoid
+    allocation and regex overhead.
+
+    Increase default UserAgents.format string builder buffer size and ensure capacity as we append user agents.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/868

--- a/service-config/src/jmh/java/com/palantir/conjure/java/api/config/service/UserAgentsBenchmark.java
+++ b/service-config/src/jmh/java/com/palantir/conjure/java/api/config/service/UserAgentsBenchmark.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.config.service;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+@SuppressWarnings("designforextension")
+public class UserAgentsBenchmark {
+
+    @Param({"service", "valid-service-name-123"})
+    private String name;
+
+    @Benchmark
+    public boolean parser() {
+        return UserAgents.isValidName(name);
+    }
+
+    @Benchmark
+    public boolean regex() {
+        return UserAgents.NAME_REGEX.matcher(name).matches();
+    }
+}

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -46,7 +46,7 @@ public final class UserAgents {
 
     /** Returns the canonical string format for the given {@link UserAgent}. */
     public static String format(UserAgent userAgent) {
-        StringBuilder formatted = new StringBuilder();
+        StringBuilder formatted = new StringBuilder(64); // preallocate larger buffer for longer agents
         formatSimpleAgent(userAgent.primary(), formatted);
         if (userAgent.nodeId().isPresent()) {
             formatted.append(" (nodeId:").append(userAgent.nodeId().get()).append(')');
@@ -59,6 +59,8 @@ public final class UserAgents {
     }
 
     private static void formatSimpleAgent(UserAgent.Agent agent, StringBuilder output) {
+        output.ensureCapacity(
+                output.length() + 1 + agent.name().length() + agent.version().length());
         output.append(agent.name()).append('/').append(agent.version());
     }
 

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -151,18 +151,26 @@ public final class UserAgents {
             return false;
         }
         char ch = name.charAt(0);
-        if (!Character.isAlphabetic(ch)) {
+        if (!isAlpha(ch)) {
             return false;
         }
 
         for (int i = 1; i < name.length(); i++) {
             ch = name.charAt(i);
-            if (!Character.isAlphabetic(ch) && !Character.isDigit(ch) && ch != '-') {
+            if (!isAlpha(ch) && !isNumeric(ch) && ch != '-') {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static boolean isAlpha(char ch) {
+        return ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z');
+    }
+
+    private static boolean isNumeric(char ch) {
+        return '0' <= ch && ch <= '9';
     }
 
     static boolean isValidNodeId(String instanceId) {

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -34,7 +34,9 @@ public final class UserAgents {
 
     private static final SafeLogger log = SafeLoggerFactory.get(UserAgents.class);
 
-    private static final Pattern NAME_REGEX = Pattern.compile("[a-zA-Z][a-zA-Z0-9\\-]*");
+    // performance note: isValidName uses hand-rolled parser to validate name effectively matches NAME_REGEX
+    // visible for testing compatibility
+    static final Pattern NAME_REGEX = Pattern.compile("[a-zA-Z][a-zA-Z0-9\\-]*");
     private static final Pattern LENIENT_VERSION_REGEX = Pattern.compile("[0-9a-z.-]+");
     private static final Pattern NODE_REGEX = Pattern.compile("[a-zA-Z0-9][a-zA-Z0-9.\\-]*");
     private static final Pattern VERSION_REGEX =
@@ -143,7 +145,24 @@ public final class UserAgents {
     }
 
     static boolean isValidName(String name) {
-        return NAME_REGEX.matcher(name).matches();
+        // hand rolled implementation of NAME_REGEX.matcher(name).matches() to avoid allocations
+        // "[a-zA-Z][a-zA-Z0-9\\-]*"
+        if (name == null || name.isEmpty()) {
+            return false;
+        }
+        char ch = name.charAt(0);
+        if (!Character.isAlphabetic(ch)) {
+            return false;
+        }
+
+        for (int i = 1; i < name.length(); i++) {
+            ch = name.charAt(i);
+            if (!Character.isAlphabetic(ch) && !Character.isDigit(ch) && ch != '-') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     static boolean isValidNodeId(String instanceId) {

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -168,4 +168,40 @@ public class UserAgentTest {
         assertThat(UserAgents.format(UserAgents.tryParse("serviceA/1.2.3 bogus|1.2.3 foo bar (boom)")))
                 .isEqualTo("serviceA/1.2.3");
     }
+
+    @Test
+    public void valid_names() {
+        assertThat("a").satisfies(UserAgentTest::isValidName);
+        assertThat("a1").satisfies(UserAgentTest::isValidName);
+        assertThat("foo").satisfies(UserAgentTest::isValidName);
+        assertThat("foo-bar").satisfies(UserAgentTest::isValidName);
+        assertThat("foo-bar123").satisfies(UserAgentTest::isValidName);
+    }
+
+    @Test
+    public void invalid_names() {
+        assertThat((String) null).satisfies(UserAgentTest::isNotValidName);
+        assertThat("").satisfies(UserAgentTest::isNotValidName);
+        assertThat(" ").satisfies(UserAgentTest::isNotValidName);
+        assertThat("1").satisfies(UserAgentTest::isNotValidName);
+        assertThat("1a").satisfies(UserAgentTest::isNotValidName);
+        assertThat("1.0").satisfies(UserAgentTest::isNotValidName);
+        assertThat("service name").satisfies(UserAgentTest::isNotValidName);
+        assertThat("service.name").satisfies(UserAgentTest::isNotValidName);
+        assertThat("service_name").satisfies(UserAgentTest::isNotValidName);
+    }
+
+    private static void isValidName(String name) {
+        assertThat(UserAgents.isValidName(name)).isTrue();
+        assertThat(name)
+                .describedAs("Name should match regex, inconsistent with isValidName for '%s'", name)
+                .matches(UserAgents.NAME_REGEX);
+    }
+
+    private static void isNotValidName(String name) {
+        assertThat(UserAgents.isValidName(name)).isFalse();
+        assertThat(name)
+                .describedAs("Name should not match regex, inconsistent with isValidName for '%s'", name)
+                .doesNotMatch(UserAgents.NAME_REGEX);
+    }
 }


### PR DESCRIPTION
## Before this PR
Similar to #864 , JFRs showing significant allocations and CPU consumed due to `com.palantir.conjure.java.api.config.service.UserAgents#isValidName` and `com.palantir.conjure.java.api.config.service.UserAgents#format` during Dialogue request processing

![image](https://user-images.githubusercontent.com/54594/180318740-42ca6b3b-e678-4d1e-af0c-3b1af9d6931a.png)
![image](https://user-images.githubusercontent.com/54594/180319030-36eb3c1f-0946-4d68-aa52-72500d72154b.png)



## After this PR
Some initial benchmark results on 16 core `Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz` where `regex` is the previous implementation and `parser` is our hand rolled non-allocating version.

```
JDK 11.0.13, OpenJDK 64-Bit Server VM, 11.0.13+8-LTS
Benchmark                                                      (name)  Mode  Cnt    Score      Error   Units
UserAgentsBenchmark.parser                                    service  avgt    3    0.021 ±    0.002   us/op
UserAgentsBenchmark.parser:·gc.alloc.rate.norm                service  avgt    3   ≈ 10⁻⁵               B/op
UserAgentsBenchmark.parser                     valid-service-name-123  avgt    3    0.073 ±    0.005   us/op
UserAgentsBenchmark.parser:·gc.alloc.rate.norm valid-service-name-123  avgt    3   ≈ 10⁻⁵               B/op
UserAgentsBenchmark.regex                                     service  avgt    3    0.092 ±    0.055   us/op
UserAgentsBenchmark.regex:·gc.alloc.rate.norm                 service  avgt    3  128.000 ±    0.001    B/op
UserAgentsBenchmark.regex                      valid-service-name-123  avgt    3    0.299 ±    0.005   us/op
UserAgentsBenchmark.regex:·gc.alloc.rate.norm  valid-service-name-123  avgt    3  200.000 ±    0.001    B/op
```

```
JDK 17.0.4, OpenJDK 64-Bit Server VM, 17.0.4+8-LTS
Benchmark                                                      (name)  Mode  Cnt     Score      Error   Units
UserAgentsBenchmark.parser                                    service  avgt    3     0.015 ±    0.002   us/op
UserAgentsBenchmark.parser:·gc.alloc.rate.norm                service  avgt    3    ≈ 10⁻⁵               B/op
UserAgentsBenchmark.parser                     valid-service-name-123  avgt    3     0.030 ±    0.001   us/op
UserAgentsBenchmark.parser:·gc.alloc.rate.norm valid-service-name-123  avgt    3    ≈ 10⁻⁵               B/op
UserAgentsBenchmark.regex                                     service  avgt    3     0.078 ±    0.021   us/op
UserAgentsBenchmark.regex:·gc.alloc.rate.norm                 service  avgt    3   128.008 ±    0.043    B/op
UserAgentsBenchmark.regex                      valid-service-name-123  avgt    3     0.251 ±    0.017   us/op
UserAgentsBenchmark.regex:·gc.alloc.rate.norm  valid-service-name-123  avgt    3   200.013 ±    0.001    B/op
```


==COMMIT_MSG==
Optimize UserAgents

Optimize UserAgents.isValidName to use a hand-rolled implementation to validate user agent name to avoid
allocation and regex overhead.

Increase default UserAgents.format string builder buffer size and ensure capacity as we append user agents.
==COMMIT_MSG==

## Possible downsides?
Complexity of maintaining is higher than simple regex