### PR TITLE
Add causes to assertion errors

### DIFF
--- a/changelog/@unreleased/pr-882.v2.yml
+++ b/changelog/@unreleased/pr-882.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Add causes to the AssertionErrors thrown by `assertThatServiceExceptionThrownBy`
+    and `assertThatRemoteExceptionThrownBy` if a throwable of the wrong class is raised
+    by the code under test.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/882

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
@@ -56,10 +56,11 @@ public class Assertions extends org.assertj.core.api.Assertions {
             throw Failures.instance().failure("Expecting code to raise a throwable.");
         }
         if (!clazz.isInstance(throwable)) {
-            throw Failures.instance()
+            throw (AssertionError) Failures.instance()
                     .failure(String.format(
                             "Expecting code to throw a %s, but caught a %s.",
-                            clazz.getCanonicalName(), throwable.getClass().getCanonicalName()));
+                            clazz.getCanonicalName(), throwable.getClass().getCanonicalName()))
+                    .initCause(throwable);
         }
     }
 }

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
@@ -39,10 +39,11 @@ public final class AssertionsTest {
     @Test
     public void testAssertThatServiceExceptionThrownBy_failsIfWrongExceptionThrown() {
         assertThatThrownBy(() -> assertThatServiceExceptionThrownBy(() -> {
-                    throw new RuntimeException();
+                    throw new RuntimeException("My runtime exception");
                 }))
                 .hasMessage("Expecting code to throw a com.palantir.conjure.java.api.errors.ServiceException,"
-                        + " but caught a java.lang.RuntimeException.");
+                        + " but caught a java.lang.RuntimeException.")
+                .hasCause(new RuntimeException("My runtime exception"));
     }
 
     @Test
@@ -64,10 +65,11 @@ public final class AssertionsTest {
     @Test
     public void testAssertThatRemoteExceptionThrownBy_failsIfWrongExceptionThrown() {
         assertThatThrownBy(() -> assertThatRemoteExceptionThrownBy(() -> {
-                    throw new RuntimeException();
+                    throw new RuntimeException("My runtime exception");
                 }))
                 .hasMessage("Expecting code to throw a com.palantir.conjure.java.api.errors.RemoteException, "
-                        + "but caught a java.lang.RuntimeException.");
+                        + "but caught a java.lang.RuntimeException.")
+                .hasCause(new RuntimeException("My runtime exception"));
     }
 
     @Test


### PR DESCRIPTION
## Before this PR

Debugging assertions that fail due to a different exception being thrown doesn't give you enough information. For example, you might be expecting a service exception and see that a remote exception is thrown. What was the error name? There's no easy way to tell.

## After this PR

==COMMIT_MSG==
Add causes to assertion errors
==COMMIT_MSG==

## Possible downsides?

The main hypothetical question I had was: is this _actually_ a cause of the AssertionError, or am I just shoving an error where it's convenient? I would argue that this really is the cause of the AssertionError. If I'm expecting a ServiceException, but some RemoteException gets thrown instead, the RemoteException really did keep my code from reaching the ServiceException I was trying to trigger.