### PR TITLE
conjure assertions provide diagnostic info for unexpected exceptions

### DIFF
--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
@@ -18,9 +18,8 @@ package com.palantir.conjure.java.api.testing;
 
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
-import org.assertj.core.api.AssertionsForClassTypes;
+import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.internal.Failures;
 import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 
@@ -39,27 +38,29 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     @CanIgnoreReturnValue
     public static ServiceExceptionAssert assertThatServiceExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
-        Throwable throwable = AssertionsForClassTypes.catchThrowable(shouldRaiseThrowable);
-        checkThrowableIsOfType(throwable, ServiceException.class);
-        return new ServiceExceptionAssert((ServiceException) throwable);
+        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(ServiceExceptionInstanceOfAssertFactory.INSTANCE);
     }
 
     @CanIgnoreReturnValue
     public static RemoteExceptionAssert assertThatRemoteExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
-        Throwable throwable = AssertionsForClassTypes.catchThrowable(shouldRaiseThrowable);
-        checkThrowableIsOfType(throwable, RemoteException.class);
-        return new RemoteExceptionAssert((RemoteException) throwable);
+        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(RemoteExceptionInstanceOfAssertFactory.INSTANCE);
     }
 
-    private static void checkThrowableIsOfType(Throwable throwable, Class<?> clazz) {
-        if (throwable == null) {
-            throw Failures.instance().failure("Expecting code to raise a throwable.");
+    private static final class ServiceExceptionInstanceOfAssertFactory
+            extends InstanceOfAssertFactory<ServiceException, ServiceExceptionAssert> {
+        static final ServiceExceptionInstanceOfAssertFactory INSTANCE = new ServiceExceptionInstanceOfAssertFactory();
+
+        ServiceExceptionInstanceOfAssertFactory() {
+            super(ServiceException.class, ServiceExceptionAssert::new);
         }
-        if (!clazz.isInstance(throwable)) {
-            throw Failures.instance()
-                    .failure(String.format(
-                            "Expecting code to throw a %s, but caught a %s.",
-                            clazz.getCanonicalName(), throwable.getClass().getCanonicalName()));
+    }
+
+    private static final class RemoteExceptionInstanceOfAssertFactory
+            extends InstanceOfAssertFactory<RemoteException, RemoteExceptionAssert> {
+        static final RemoteExceptionInstanceOfAssertFactory INSTANCE = new RemoteExceptionInstanceOfAssertFactory();
+
+        RemoteExceptionInstanceOfAssertFactory() {
+            super(RemoteException.class, RemoteExceptionAssert::new);
         }
     }
 }

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
@@ -41,7 +41,7 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
     public final ServiceExceptionAssert hasArgs(Arg<?>... args) {
         isNotNull();
 
-        AssertableArgs actualArgs = new AssertableArgs(actual.getParameters());
+        AssertableArgs actualArgs = new AssertableArgs(actual.getArgs());
         AssertableArgs expectedArgs = new AssertableArgs(Arrays.asList(args));
 
         failIfNotEqual("Expected safe args to be %s, but found %s", expectedArgs.safeArgs, actualArgs.safeArgs);
@@ -73,7 +73,7 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
     public final ServiceExceptionAssert containsArgs(Arg<?>... args) {
         isNotNull();
 
-        AssertableArgs actualArgs = new AssertableArgs(actual.getParameters());
+        AssertableArgs actualArgs = new AssertableArgs(actual.getArgs());
         AssertableArgs expectedArgs = new AssertableArgs(Arrays.asList(args));
 
         failIfDoesNotContain(

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
@@ -33,7 +33,7 @@ public final class AssertionsTest {
         assertThatThrownBy(() -> assertThatServiceExceptionThrownBy(() -> {
                     // Not going to throw anything
                 }))
-                .hasMessage("Expecting code to raise a throwable.");
+                .hasMessageContaining("Expecting code to raise a throwable.");
     }
 
     @Test
@@ -41,8 +41,8 @@ public final class AssertionsTest {
         assertThatThrownBy(() -> assertThatServiceExceptionThrownBy(() -> {
                     throw new RuntimeException();
                 }))
-                .hasMessage("Expecting code to throw a com.palantir.conjure.java.api.errors.ServiceException,"
-                        + " but caught a java.lang.RuntimeException.");
+                .hasMessageContaining(
+                        "com.palantir.conjure.java.api.errors.ServiceException", "java.lang.RuntimeException");
     }
 
     @Test
@@ -58,7 +58,7 @@ public final class AssertionsTest {
         assertThatThrownBy(() -> assertThatRemoteExceptionThrownBy(() -> {
                     // Not going to throw anything
                 }))
-                .hasMessage("Expecting code to raise a throwable.");
+                .hasMessageContaining("Expecting code to raise a throwable.");
     }
 
     @Test
@@ -66,8 +66,8 @@ public final class AssertionsTest {
         assertThatThrownBy(() -> assertThatRemoteExceptionThrownBy(() -> {
                     throw new RuntimeException();
                 }))
-                .hasMessage("Expecting code to throw a com.palantir.conjure.java.api.errors.RemoteException, "
-                        + "but caught a java.lang.RuntimeException.");
+                .hasMessageContaining(
+                        "com.palantir.conjure.java.api.errors.RemoteException", "java.lang.RuntimeException");
     }
 
     @Test


### PR DESCRIPTION
This is based on the idea provided by #882, implemented to use
standard assertj types and provide feedback consistent with builtin
assertj checks.

==COMMIT_MSG==
conjure assertions provide diagnostic info for unexpected exceptions
==COMMIT_MSG==

