### PR TITLE
Add UserAgents.of(UserAgent, Iterable<Agent>)

### DIFF
--- a/changelog/@unreleased/pr-902.v2.yml
+++ b/changelog/@unreleased/pr-902.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add UserAgents.of(UserAgent, Iterable<Agent>)
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/902

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.api.config.service;
 
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -86,13 +87,14 @@ public interface UserAgent {
 
         @Value.Check
         default void check() {
-            Preconditions.checkArgument(
-                    UserAgents.isValidName(name()), "Illegal agent name format", SafeArg.of("name", name()));
-            // Should never hit the following.
-            Preconditions.checkArgument(
-                    UserAgents.isValidVersion(version()),
-                    "Illegal version format. This is a bug",
-                    SafeArg.of("version", version()));
+            if (!UserAgents.isValidName(name())) {
+                throw new SafeIllegalArgumentException("Illegal agent name format", SafeArg.of("name", name()));
+            }
+            if (!UserAgents.isValidVersion(version())) {
+                // Should never hit the following.
+                throw new SafeIllegalArgumentException(
+                        "Illegal version format. This is a bug", SafeArg.of("version", version()));
+            }
         }
 
         static Agent of(String name, String version) {

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
@@ -58,6 +58,16 @@ public interface UserAgent {
     }
 
     /**
+     * Returns a user agent with the given base agent combined with specified additional informational agents.
+     */
+    static UserAgent of(UserAgent base, Iterable<Agent> additional) {
+        return ImmutableUserAgent.builder()
+                .from(base)
+                .addAllInformational(additional)
+                .build();
+    }
+
+    /**
      * Returns a new {@link UserAgent} instance whose {@link #informational} agents are this instance's agents plus the
      * given agent.
      */

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.api.config.service;
 
-import com.palantir.conjure.java.api.config.service.UserAgent.Agent;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
@@ -46,16 +45,6 @@ public final class UserAgents {
             Pattern.compile(String.format("(%s)/(%s)( \\((.+?)\\))?", NAME_REGEX, LENIENT_VERSION_REGEX));
 
     private UserAgents() {}
-
-    /**
-     * Returns a user agent with the given base agent combined with specified additional informational agents.
-     */
-    public static UserAgent of(UserAgent base, Iterable<Agent> additional) {
-        return ImmutableUserAgent.builder()
-                .from(base)
-                .addAllInformational(additional)
-                .build();
-    }
 
     /** Returns the canonical string format for the given {@link UserAgent}. */
     public static String format(UserAgent userAgent) {

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.api.config.service;
 
+import com.palantir.conjure.java.api.config.service.UserAgent.Agent;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
@@ -45,6 +46,16 @@ public final class UserAgents {
             Pattern.compile(String.format("(%s)/(%s)( \\((.+?)\\))?", NAME_REGEX, LENIENT_VERSION_REGEX));
 
     private UserAgents() {}
+
+    /**
+     * Returns a user agent with the given base agent combined with specified additional informational agents.
+     */
+    public static UserAgent of(UserAgent base, Iterable<Agent> additional) {
+        return ImmutableUserAgent.builder()
+                .from(base)
+                .addAllInformational(additional)
+                .build();
+    }
 
     /** Returns the canonical string format for the given {@link UserAgent}. */
     public static String format(UserAgent userAgent) {

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -67,22 +67,22 @@ public class UserAgentTest {
     void testPrimaryWithInformational() {
         UserAgent baseUserAgent = UserAgent.of(Agent.of("service", "1.0.0"));
         List<Agent> info = ImmutableList.of(Agent.of("conjure", "1.2.3"), Agent.of("jdk", "17.0.4.1"));
-        UserAgent first = UserAgents.of(baseUserAgent, info);
+        UserAgent first = UserAgent.of(baseUserAgent, info);
         assertThat(first).satisfies(agent -> {
             assertThat(agent.primary()).isEqualTo(baseUserAgent.primary());
             assertThat(agent.informational()).hasSize(2).isEqualTo(info);
             assertThat(UserAgents.format(agent)).isEqualTo("service/1.0.0 conjure/1.2.3 jdk/17.0.4.1");
             assertThat(UserAgents.parse(UserAgents.format(agent))).isEqualTo(agent);
-            assertThat(UserAgents.of(agent, ImmutableList.of())).isEqualTo(agent);
+            assertThat(UserAgent.of(agent, ImmutableList.of())).isEqualTo(agent);
         });
 
         List<Agent> moreInfo = ImmutableList.of(Agent.of("test", "4.5.6"));
-        assertThat(UserAgents.of(first, moreInfo)).satisfies(agent -> {
+        assertThat(UserAgent.of(first, moreInfo)).satisfies(agent -> {
             assertThat(agent.primary()).isEqualTo(baseUserAgent.primary());
             assertThat(agent.informational()).hasSize(3).containsExactlyElementsOf(Iterables.concat(info, moreInfo));
             assertThat(UserAgents.format(agent)).isEqualTo("service/1.0.0 conjure/1.2.3 jdk/17.0.4.1 test/4.5.6");
             assertThat(UserAgents.parse(UserAgents.format(agent))).isEqualTo(agent);
-            assertThat(UserAgents.of(agent, ImmutableList.of())).isEqualTo(agent);
+            assertThat(UserAgent.of(agent, ImmutableList.of())).isEqualTo(agent);
         });
     }
 

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -19,7 +19,11 @@ package com.palantir.conjure.java.api.config.service;
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.palantir.conjure.java.api.config.service.UserAgent.Agent;
 import com.palantir.logsafe.SafeArg;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class UserAgentTest {
@@ -57,6 +61,29 @@ public class UserAgentTest {
 
         UserAgent derivedAgent = baseUserAgent.addAgent(UserAgent.Agent.of("conjure", "2.0.0"));
         assertThat(UserAgents.format(derivedAgent)).isEqualTo("service/1.0.0 conjure/2.0.0");
+    }
+
+    @Test
+    void testPrimaryWithInformational() {
+        UserAgent baseUserAgent = UserAgent.of(Agent.of("service", "1.0.0"));
+        List<Agent> info = ImmutableList.of(Agent.of("conjure", "1.2.3"), Agent.of("jdk", "17.0.4.1"));
+        UserAgent first = UserAgents.of(baseUserAgent, info);
+        assertThat(first).satisfies(agent -> {
+            assertThat(agent.primary()).isEqualTo(baseUserAgent.primary());
+            assertThat(agent.informational()).hasSize(2).isEqualTo(info);
+            assertThat(UserAgents.format(agent)).isEqualTo("service/1.0.0 conjure/1.2.3 jdk/17.0.4.1");
+            assertThat(UserAgents.parse(UserAgents.format(agent))).isEqualTo(agent);
+            assertThat(UserAgents.of(agent, ImmutableList.of())).isEqualTo(agent);
+        });
+
+        List<Agent> moreInfo = ImmutableList.of(Agent.of("test", "4.5.6"));
+        assertThat(UserAgents.of(first, moreInfo)).satisfies(agent -> {
+            assertThat(agent.primary()).isEqualTo(baseUserAgent.primary());
+            assertThat(agent.informational()).hasSize(3).containsExactlyElementsOf(Iterables.concat(info, moreInfo));
+            assertThat(UserAgents.format(agent)).isEqualTo("service/1.0.0 conjure/1.2.3 jdk/17.0.4.1 test/4.5.6");
+            assertThat(UserAgents.parse(UserAgents.format(agent))).isEqualTo(agent);
+            assertThat(UserAgents.of(agent, ImmutableList.of())).isEqualTo(agent);
+        });
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Creating a `UserAgent` with multiple additional informational agents required several immutable object creations. See https://github.com/palantir/dialogue/pull/1797 for example

## After this PR
==COMMIT_MSG==
Add UserAgents.of(UserAgent, Iterable<Agent>)
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

