### PR TITLE
Reduce noisy user agent logging to debug

### DIFF
--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -183,7 +183,10 @@ public final class UserAgents {
             return true;
         }
 
-        log.warn("Encountered invalid user agent version '{}'", SafeArg.of("version", version));
+        if (log.isDebugEnabled()) {
+            log.debug("Encountered invalid user agent version '{}'", SafeArg.of("version", version));
+        }
+
         return false;
     }
 


### PR DESCRIPTION
We started seeing a ton of these logs. This log probably is not appropriate for `warn`.

![Screen Shot 2022-11-21 at 2 34 16 PM](https://user-images.githubusercontent.com/5273164/203172614-68012892-8368-41af-a1f7-c62c1331f5ba.png)