### PR TITLE
Add a reason field to QosException

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
@@ -34,13 +34,21 @@ import java.util.Optional;
  */
 public abstract class QosException extends RuntimeException {
 
+    private final QosReason reason;
+
     // Not meant for external subclassing.
-    private QosException(String message) {
+    private QosException(String message, QosReason reason) {
         super(message);
+        this.reason = reason;
     }
 
-    private QosException(String message, Throwable cause) {
+    private QosException(String message, Throwable cause, QosReason reason) {
         super(message, cause);
+        this.reason = reason;
+    }
+
+    public QosReason getReason() {
+        return reason;
     }
 
     public abstract <T> T accept(Visitor<T> visitor);
@@ -62,10 +70,24 @@ public abstract class QosException extends RuntimeException {
     }
 
     /**
+     * Like {@link #throttle()}, but includes a reason.
+     */
+    public static Throttle throttle(QosReason reason) {
+        return new Throttle(Optional.empty(), reason);
+    }
+
+    /**
      * Like {@link #throttle()}, but includes a cause.
      */
     public static Throttle throttle(Throwable cause) {
         return new Throttle(Optional.empty(), cause);
+    }
+
+    /**
+     * Like {@link #throttle()}, but includes a reason, and a cause.
+     */
+    public static Throttle throttle(QosReason reason, Throwable cause) {
+        return new Throttle(Optional.empty(), cause, reason);
     }
 
     /**
@@ -77,10 +99,24 @@ public abstract class QosException extends RuntimeException {
     }
 
     /**
+     * Like {@link #throttle(Duration)}, but includes a reason.
+     */
+    public static Throttle throttle(QosReason reason, Duration duration) {
+        return new Throttle(Optional.of(duration), reason);
+    }
+
+    /**
      * Like {@link #throttle(Duration)}, but includes a cause.
      */
     public static Throttle throttle(Duration duration, Throwable cause) {
         return new Throttle(Optional.of(duration), cause);
+    }
+
+    /**
+     * Like {@link #throttle(Duration)}, but includes a reason, and a cause.
+     */
+    public static Throttle throttle(QosReason reason, Duration duration, Throwable cause) {
+        return new Throttle(Optional.of(duration), cause, reason);
     }
 
     /**
@@ -92,10 +128,24 @@ public abstract class QosException extends RuntimeException {
     }
 
     /**
+     * Like {@link #retryOther(URL)}, but includes a reason.
+     */
+    public static RetryOther retryOther(QosReason reason, URL redirectTo) {
+        return new RetryOther(redirectTo, reason);
+    }
+
+    /**
      * Like {@link #retryOther(URL)}, but includes a cause.
      */
     public static RetryOther retryOther(URL redirectTo, Throwable cause) {
         return new RetryOther(redirectTo, cause);
+    }
+
+    /**
+     * Like {@link #retryOther(URL)}, but includes a reason, and a cause.
+     */
+    public static RetryOther retryOther(QosReason reason, URL redirectTo, Throwable cause) {
+        return new RetryOther(redirectTo, cause, reason);
     }
 
     /**
@@ -107,23 +157,51 @@ public abstract class QosException extends RuntimeException {
     }
 
     /**
+     * Like {@link #unavailable()}, but includes a reason.
+     */
+    public static Unavailable unavailable(QosReason reason) {
+        return new Unavailable(reason);
+    }
+
+    /**
      * Like {@link #unavailable()}, but includes a cause.
      */
     public static Unavailable unavailable(Throwable cause) {
         return new Unavailable(cause);
     }
 
+    /**
+     * Like {@link #unavailable()}, but includes a reason, and a cause.
+     */
+    public static Unavailable unavailable(QosReason reason, Throwable cause) {
+        return new Unavailable(cause, reason);
+    }
+
     /** See {@link #throttle}. */
     public static final class Throttle extends QosException implements SafeLoggable {
+        private static final QosReason DEFAULT_REASON = QosReason.of("qos-throttle");
         private final Optional<Duration> retryAfter;
 
         private Throttle(Optional<Duration> retryAfter) {
-            super("Suggesting request throttling with optional retryAfter duration: " + retryAfter);
+            super("Suggesting request throttling with optional retryAfter duration: " + retryAfter, DEFAULT_REASON);
+            this.retryAfter = retryAfter;
+        }
+
+        private Throttle(Optional<Duration> retryAfter, QosReason reason) {
+            super("Suggesting request throttling with optional retryAfter duration: " + retryAfter, reason);
             this.retryAfter = retryAfter;
         }
 
         private Throttle(Optional<Duration> retryAfter, Throwable cause) {
-            super("Suggesting request throttling with optional retryAfter duration: " + retryAfter, cause);
+            super(
+                    "Suggesting request throttling with optional retryAfter duration: " + retryAfter,
+                    cause,
+                    DEFAULT_REASON);
+            this.retryAfter = retryAfter;
+        }
+
+        private Throttle(Optional<Duration> retryAfter, Throwable cause, QosReason reason) {
+            super("Suggesting request throttling with optional retryAfter duration: " + retryAfter, cause, reason);
             this.retryAfter = retryAfter;
         }
 
@@ -149,15 +227,26 @@ public abstract class QosException extends RuntimeException {
 
     /** See {@link #retryOther}. */
     public static final class RetryOther extends QosException implements SafeLoggable {
+        private static final QosReason DEFAULT_REASON = QosReason.of("qos-retry-other");
         private final URL redirectTo;
 
         private RetryOther(URL redirectTo) {
-            super("Suggesting request retry against: " + redirectTo.toString());
+            super("Suggesting request retry against: " + redirectTo.toString(), DEFAULT_REASON);
+            this.redirectTo = redirectTo;
+        }
+
+        private RetryOther(URL redirectTo, QosReason reason) {
+            super("Suggesting request retry against: " + redirectTo.toString(), reason);
             this.redirectTo = redirectTo;
         }
 
         private RetryOther(URL redirectTo, Throwable cause) {
-            super("Suggesting request retry against: " + redirectTo.toString(), cause);
+            super("Suggesting request retry against: " + redirectTo.toString(), cause, DEFAULT_REASON);
+            this.redirectTo = redirectTo;
+        }
+
+        private RetryOther(URL redirectTo, Throwable cause, QosReason reason) {
+            super("Suggesting request retry against: " + redirectTo.toString(), cause, reason);
             this.redirectTo = redirectTo;
         }
 
@@ -184,14 +273,24 @@ public abstract class QosException extends RuntimeException {
 
     /** See {@link #unavailable}. */
     public static final class Unavailable extends QosException implements SafeLoggable {
+        private static final QosReason DEFAULT_REASON = QosReason.of("qos-unavailable");
+
         private static final String SERVER_UNAVAILABLE = "Server unavailable";
 
         private Unavailable() {
-            super(SERVER_UNAVAILABLE);
+            super(SERVER_UNAVAILABLE, DEFAULT_REASON);
+        }
+
+        private Unavailable(QosReason reason) {
+            super(SERVER_UNAVAILABLE, reason);
         }
 
         private Unavailable(Throwable cause) {
-            super(SERVER_UNAVAILABLE, cause);
+            super(SERVER_UNAVAILABLE, cause, DEFAULT_REASON);
+        }
+
+        private Unavailable(Throwable cause, QosReason reason) {
+            super(SERVER_UNAVAILABLE, cause, reason);
         }
 
         @Override

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.google.errorprone.annotations.CompileTimeConstant;
+import java.util.Objects;
+
+public final class QosReason {
+
+    @CompileTimeConstant
+    private final String name;
+
+    private QosReason(@CompileTimeConstant String name) {
+        this.name = name;
+    }
+
+    public static QosReason of(@CompileTimeConstant String name) {
+        return new QosReason(name);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        } else if (!(other instanceof QosReason)) {
+            return false;
+        } else {
+            QosReason otherReason = (QosReason) other;
+            return Objects.equals(this.name, otherReason.name);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.name);
+    }
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java
@@ -17,7 +17,11 @@
 package com.palantir.conjure.java.api.errors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import com.palantir.conjure.java.api.errors.QosException.RetryOther;
+import com.palantir.conjure.java.api.errors.QosException.Throttle;
+import com.palantir.conjure.java.api.errors.QosException.Unavailable;
 import java.net.URL;
 import org.junit.jupiter.api.Test;
 
@@ -46,5 +50,21 @@ public final class QosExceptionTest {
         assertThat(QosException.retryOther(new URL("http://foo")).accept(visitor))
                 .isEqualTo(QosException.RetryOther.class);
         assertThat(QosException.unavailable().accept(visitor)).isEqualTo(QosException.Unavailable.class);
+    }
+
+    @Test
+    public void testReason() {
+        QosReason reason = QosReason.of("reason");
+        assertThat(QosException.throttle(reason).getReason()).isEqualTo(reason);
+    }
+
+    @Test
+    public void testDefaultReasons() {
+        assertThat(QosException.throttle().getReason().toString()).isEqualTo(Throttle.DEFAULT_REASON);
+        assertThatNoException().isThrownBy(() -> assertThat(QosException.retryOther(new URL("http://foo"))
+                        .getReason()
+                        .toString())
+                .isEqualTo(RetryOther.DEFAULT_REASON));
+        assertThat(QosException.unavailable().getReason().toString()).isEqualTo(Unavailable.DEFAULT_REASON);
     }
 }


### PR DESCRIPTION
## Before this PR
Services throw `QosException`s to protect themselves from becoming overloaded. It's useful to know why a service responded with a `QosException` for better observability. However, the exceptions are currently logged at the `debug` level, which is disabled by default. It would be costly to log the exceptions at an `info` (or higher) level. 

This PR introduces new `QosException` factory methods which allow users to store a reason (an object of newly defined type `QosReason`) for throwing an exception.

## After this PR
==COMMIT_MSG==
Add a reason field to QosException
==COMMIT_MSG==
