### PR TITLE
Ensure QosReason cannot be null

### DIFF
--- a/changelog/@unreleased/pr-929.v2.yml
+++ b/changelog/@unreleased/pr-929.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Ensure QosReason cannot be provided as `null` by throwing an exception
+    immediately
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/929

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.api.errors;
 
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.UnsafeArg;
@@ -39,12 +40,12 @@ public abstract class QosException extends RuntimeException {
     // Not meant for external subclassing.
     private QosException(String message, QosReason reason) {
         super(message);
-        this.reason = reason;
+        this.reason = Preconditions.checkNotNull(reason, "QosReason is required");
     }
 
     private QosException(String message, Throwable cause, QosReason reason) {
         super(message, cause);
-        this.reason = reason;
+        this.reason = Preconditions.checkNotNull(reason, "QosReason is required");
     }
 
     public final QosReason getReason() {


### PR DESCRIPTION
## Before this PR
The API doesn't describe that nulls are allowed, however it didn't fail fast either when null values are provided.

## After this PR
==COMMIT_MSG==
Ensure QosReason cannot be provided as `null` by throwing an exception immediately
==COMMIT_MSG==

