### PR TITLE
Apply the Jetbrains Pattern annotation to the QosReason ctor

### DIFF
--- a/changelog/@unreleased/pr-932.v2.yml
+++ b/changelog/@unreleased/pr-932.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Apply the Jetbrains Pattern annotation to the QosReason ctor
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/932

--- a/errors/build.gradle
+++ b/errors/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind"
     api "com.google.code.findbugs:jsr305"
     api "com.palantir.safe-logging:safe-logging"
+    api "org.jetbrains:annotations"
     implementation "com.palantir.safe-logging:preconditions"
 
     testImplementation project(":extras:jackson-support")

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
@@ -35,13 +35,15 @@ public final class QosReason {
     @CompileTimeConstant
     private final String reason;
 
-    private static final Pattern PATTERN = Pattern.compile("^[a-z0-9\\-]{1,50}$");
+    private static final String PATTERN_STRING = "^[a-z0-9\\-]{1,50}$";
+    private static final Pattern PATTERN = Pattern.compile(PATTERN_STRING);
 
     private QosReason(@CompileTimeConstant String reason) {
         this.reason = reason;
     }
 
-    public static QosReason of(@CompileTimeConstant String reason) {
+    public static QosReason of(
+            @CompileTimeConstant @org.intellij.lang.annotations.Pattern(PATTERN_STRING) String reason) {
         Preconditions.checkArgument(
                 PATTERN.matcher(reason).matches(),
                 "Reason must be at most 50 characters, and only contain lowercase letters, numbers, "


### PR DESCRIPTION
This provides immediate IDE feedback when values are passed that don't satisfy our regex. This pattern is helpful for constant-string inputs, but requires additional IDE config if we begin to use it elsewhere that constants aren't required (e.g. ErrorType names) unless we disable the editor validation that all inputs can be traced to a constant value.
<img width="923" alt="Screen Shot 2022-12-15 at 1 17 30 PM" src="https://user-images.githubusercontent.com/3854321/207937265-6e4b2b0a-5239-46f4-8f70-99667bcc2cc4.png">

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Apply the Jetbrains Pattern annotation to the QosReason ctor
==COMMIT_MSG==

## Possible downsides?
API dependency on jetbrains annotations. We already do this in safe-logging preconditions and conjure for their `@Contract` annotation.

