### PR TITLE
Better error message for HostAndPort containing a protocol

### DIFF
--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/HostAndPort.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/HostAndPort.java
@@ -34,6 +34,7 @@ package com.palantir.conjure.java.api.config.service;
 
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import org.jetbrains.annotations.VisibleForTesting;
 
 /** See Guava's {@code HostAndPort}. This class is a re-implementation that throws safelog exceptions. */
@@ -92,6 +93,16 @@ public final class HostAndPort {
             Preconditions.checkArgument(
                     isValidPort(port), "Port number out of range", SafeArg.of("port", hostPortString));
         }
+
+        // Additional validation for common errors. An alternative to this diff between conjure HostAndPort and
+        // Guava HostAndPort would be to use Guava's HostSpecifier.from() here instead.  But that would require
+        // either re-adding a Guava dependency (removed earlier in this repo's history), or copying that class
+        // and its dependencies (InetAddresses, InternetDomainName, Ascii.toLowerCase, Splitter, Joiner, and more)
+        // into this repo like we did with HostAndPort.
+        Preconditions.checkArgument(
+                !host.contains("://"),
+                "hostPortString must not contain a protocol prefix like http:// or https://",
+                UnsafeArg.of("hostPortString", hostPortString));
 
         return new HostAndPort(host, port);
     }

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/HostAndPort.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/HostAndPort.java
@@ -34,8 +34,9 @@ package com.palantir.conjure.java.api.config.service;
 
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import org.jetbrains.annotations.VisibleForTesting;
 
-/** See Guava's {@code HostAndPort}. */
+/** See Guava's {@code HostAndPort}. This class is a re-implementation that throws safelog exceptions. */
 public final class HostAndPort {
     /** Magic value indicating the absence of a port number. */
     private static final int NO_PORT = -1;
@@ -146,5 +147,15 @@ public final class HostAndPort {
     /** Return true for valid port numbers. */
     private static boolean isValidPort(int port) {
         return port >= 0 && port <= 65535;
+    }
+
+    @VisibleForTesting
+    String getHost() {
+        return host;
+    }
+
+    @VisibleForTesting
+    int getPort() {
+        return port;
     }
 }

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/HostAndPortTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/HostAndPortTest.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.config.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class HostAndPortTest {
+
+    @Test
+    void fromString_onHostAndPort_succeeds() {
+        HostAndPort hostAndPort = HostAndPort.fromString("example.com:8080");
+        assertThat(hostAndPort.getHost()).isEqualTo("example.com");
+        assertThat(hostAndPort.getPort()).isEqualTo(8080);
+    }
+
+    @Test
+    void fromString_onHostAndPortWithHttpProtocolPrefix_doesNotThrow() {
+        HostAndPort hostAndPort = HostAndPort.fromString("http://example.com:8080");
+        assertThat(hostAndPort.getHost()).isEqualTo("http://example.com:8080");
+        assertThat(hostAndPort.getPort()).isEqualTo(-1);
+    }
+}

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/HostAndPortTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/HostAndPortTest.java
@@ -16,8 +16,10 @@
 
 package com.palantir.conjure.java.api.config.service;
 
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.logsafe.UnsafeArg;
 import org.junit.jupiter.api.Test;
 
 class HostAndPortTest {
@@ -31,8 +33,22 @@ class HostAndPortTest {
 
     @Test
     void fromString_onHostAndPortWithHttpProtocolPrefix_doesNotThrow() {
-        HostAndPort hostAndPort = HostAndPort.fromString("http://example.com:8080");
-        assertThat(hostAndPort.getHost()).isEqualTo("http://example.com:8080");
-        assertThat(hostAndPort.getPort()).isEqualTo(-1);
+        assertThatLoggableExceptionThrownBy(() -> HostAndPort.fromString("http://example.com:8080"))
+                .hasMessageContaining("hostPortString must not contain a protocol prefix like http:// or https://")
+                .containsArgs(UnsafeArg.of("hostPortString", "http://example.com:8080"));
+    }
+
+    @Test
+    void fromString_onHostAndPortWithHttpsProtocolPrefix_doesNotThrow() {
+        assertThatLoggableExceptionThrownBy(() -> HostAndPort.fromString("https://example.com:8080"))
+                .hasMessageContaining("hostPortString must not contain a protocol prefix like http:// or https://")
+                .containsArgs(UnsafeArg.of("hostPortString", "https://example.com:8080"));
+    }
+
+    @Test
+    void fromString_onHostAndPortWithAbcProtocolPrefix_doesNotThrow() {
+        assertThatLoggableExceptionThrownBy(() -> HostAndPort.fromString("abc://example.com:8080"))
+                .hasMessageContaining("hostPortString must not contain a protocol prefix like http:// or https://")
+                .containsArgs(UnsafeArg.of("hostPortString", "abc://example.com:8080"));
     }
 }

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
@@ -147,4 +147,14 @@ public final class ProxyConfigurationTests {
         assertThat(ObjectMappers.newClientObjectMapper().readValue(kebabCase, ProxyConfiguration.class))
                 .isEqualTo(config);
     }
+
+    @Test
+    public void incorrectlyFormattedHostAndPort() {
+        assertThatThrownBy(() -> ProxyConfiguration.builder()
+                        .hostAndPort("http://squid:3128")
+                        .type(ProxyConfiguration.Type.HTTP)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Given hostname does not contain a port number: {hostname=[http://squid:3128]}");
+    }
 }

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.api.config.service;
 
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.io.Resources;
 import com.palantir.conjure.java.api.ext.jackson.ObjectMappers;
+import com.palantir.logsafe.UnsafeArg;
 import java.io.IOException;
 import java.net.URL;
 import org.junit.jupiter.api.Test;
@@ -150,11 +152,11 @@ public final class ProxyConfigurationTests {
 
     @Test
     public void incorrectlyFormattedHostAndPort() {
-        assertThatThrownBy(() -> ProxyConfiguration.builder()
+        assertThatLoggableExceptionThrownBy(() -> ProxyConfiguration.builder()
                         .hostAndPort("http://squid:3128")
                         .type(ProxyConfiguration.Type.HTTP)
                         .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Given hostname does not contain a port number: {hostname=[http://squid:3128]}");
+                .hasMessageContaining("hostPortString must not contain a protocol prefix like http:// or https://")
+                .containsArgs(UnsafeArg.of("hostPortString", "http://squid:3128"));
     }
 }


### PR DESCRIPTION
## Before this PR
There was an internal report (`ptcom/public-docs/pull/1359`) of a long debugging session that root caused to incorrectly specifying `hostAndPort: https://proxy-host.com:3128` instead of `hostAndPort: proxy-host.com:3128` in this configuration.

Before this PR, that would be easy to miss in the error message:

```
Given hostname does not contain a port number: {hostname=[http://squid:3128]}
```

## After this PR
==COMMIT_MSG==
Better error message for HostAndPort containing a protocol
==COMMIT_MSG==

With this PR, the error message would instead be:
```
hostPortString must not contain a protocol prefix like http:// or https://
```

To see the behavior change more clearly, look at just the second commit's diff (the first commit adds tests establishing current behavior).

## Possible downsides?
This PR performs more validation in the HostAndPort class, so any existing instances of values containing `://` would now start failing to deserialize.  The only usage of HostAndPort in this repo is in ProxyConfiguration which already fails during deserialization: https://github.com/palantir/conjure-java-runtime-api/blob/acf99a6a77403cd8080b42ce34fd298b766d01ca/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java#L95-L97.  So there would have to be a usage of HostAndPort directly, not via ProxyConfiguration.  Searching internal sourcegraph for `import com.palantir.conjure.java.api.config.service.HostAndPort` I see only one repo doing this.
