### PR TITLE
Add QosExcepetion assertions

### DIFF
--- a/changelog/@unreleased/pr-985.v2.yml
+++ b/changelog/@unreleased/pr-985.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add `QosExcepetion` assertions
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/985

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.api.testing;
 
+import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import org.assertj.core.api.InstanceOfAssertFactory;
@@ -36,6 +37,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new RemoteExceptionAssert(actual);
     }
 
+    public static QosExceptionAssert assertThat(QosException actual) {
+        return new QosExceptionAssert(actual);
+    }
+
     @CanIgnoreReturnValue
     public static ServiceExceptionAssert assertThatServiceExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
         return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(ServiceExceptionInstanceOfAssertFactory.INSTANCE);
@@ -44,6 +49,11 @@ public class Assertions extends org.assertj.core.api.Assertions {
     @CanIgnoreReturnValue
     public static RemoteExceptionAssert assertThatRemoteExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
         return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(RemoteExceptionInstanceOfAssertFactory.INSTANCE);
+    }
+
+    @CanIgnoreReturnValue
+    public static QosExceptionAssert assertThatQosExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
+        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(QosExceptionInstanceOfAssertFactory.INSTANCE);
     }
 
     private static final class ServiceExceptionInstanceOfAssertFactory
@@ -61,6 +71,15 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
         RemoteExceptionInstanceOfAssertFactory() {
             super(RemoteException.class, RemoteExceptionAssert::new);
+        }
+    }
+
+    private static final class QosExceptionInstanceOfAssertFactory
+            extends InstanceOfAssertFactory<QosException, QosExceptionAssert> {
+        static final QosExceptionInstanceOfAssertFactory INSTANCE = new QosExceptionInstanceOfAssertFactory();
+
+        QosExceptionInstanceOfAssertFactory() {
+            super(QosException.class, QosExceptionAssert::new);
         }
     }
 }

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/QosExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/QosExceptionAssert.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.testing;
+
+import com.palantir.conjure.java.api.errors.QosException;
+import com.palantir.conjure.java.api.errors.QosReason;
+import java.util.Objects;
+import org.assertj.core.api.AbstractThrowableAssert;
+
+public class QosExceptionAssert extends AbstractThrowableAssert<QosExceptionAssert, QosException> {
+
+    QosExceptionAssert(QosException actual) {
+        super(actual, QosExceptionAssert.class);
+    }
+
+    public final QosExceptionAssert hasReason(QosReason reason) {
+        isNotNull();
+        failIfNotEqual("Expected QosReason to be %s, but found %s", reason, actual.getReason());
+        return this;
+    }
+
+    private void failIfNotEqual(String message, Object expected, Object actual) {
+        if (!Objects.equals(expected, actual)) {
+            failWithMessage(message, expected, actual);
+        }
+    }
+}

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
@@ -16,11 +16,14 @@
 
 package com.palantir.conjure.java.api.testing;
 
+import static com.palantir.conjure.java.api.testing.Assertions.assertThatQosExceptionThrownBy;
 import static com.palantir.conjure.java.api.testing.Assertions.assertThatRemoteExceptionThrownBy;
 import static com.palantir.conjure.java.api.testing.Assertions.assertThatServiceExceptionThrownBy;
 import static com.palantir.conjure.java.api.testing.Assertions.assertThatThrownBy;
 
 import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.QosException;
+import com.palantir.conjure.java.api.errors.QosReason;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.api.errors.ServiceException;
@@ -82,5 +85,32 @@ public final class AssertionsTest {
                             ErrorType.INTERNAL.httpErrorCode());
                 })
                 .isGeneratedFromErrorType(ErrorType.INTERNAL);
+    }
+
+    @Test
+    public void testAssertThatQosExceptionThrownBy_failsIfNothingThrown() {
+        assertThatThrownBy(() -> assertThatQosExceptionThrownBy(() -> {
+                    // Not going to throw anything
+                }))
+                .hasMessageContaining("Expecting code to raise a throwable.");
+    }
+
+    @Test
+    public void testAssertThatQosExceptionThrownBy_failsIfWrongExceptionThrown() {
+        assertThatThrownBy(() -> assertThatQosExceptionThrownBy(() -> {
+                    throw new RuntimeException("My message");
+                }))
+                .hasMessageContaining(
+                        "com.palantir.conjure.java.api.errors.QosException",
+                        "java.lang.RuntimeException",
+                        "My message");
+    }
+
+    @Test
+    public void testAssertThatQosExceptionThrownBy_catchesQosException() {
+        assertThatQosExceptionThrownBy(() -> {
+                    throw QosException.unavailable(QosReason.of("reason"));
+                })
+                .hasReason(QosReason.of("reason"));
     }
 }

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/QosExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/QosExceptionAssertTest.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.testing;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.conjure.java.api.errors.QosException;
+import com.palantir.conjure.java.api.errors.QosReason;
+import org.junit.jupiter.api.Test;
+
+public final class QosExceptionAssertTest {
+
+    @Test
+    public void testSanity() {
+        QosReason reason = QosReason.of("reason");
+
+        Assertions.assertThat(QosException.unavailable(reason)).hasReason(reason);
+
+        assertThatThrownBy(() -> Assertions.assertThat(QosException.unavailable(QosReason.of("other")))
+                        .hasReason(reason))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Expected QosReason to be reason, but found other");
+    }
+}

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/RemoteExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/RemoteExceptionAssertTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 public final class RemoteExceptionAssertTest {
 
     @Test
-    public void testSanity() throws Exception {
+    public void testSanity() {
         ErrorType actualType = ErrorType.FAILED_PRECONDITION;
         SerializableError error = SerializableError.forException(new ServiceException(actualType));
 


### PR DESCRIPTION
Provide a more ergonomic way to assert `QosException`, like we do for `ServiceException` and `RemoteException`.