### PR TITLE
(Unknown)RemoteException implement ResponseStatus

### DIFF
--- a/changelog/@unreleased/pr-1026.v2.yml
+++ b/changelog/@unreleased/pr-1026.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: (Unknown)RemoteException implement ResponseStatus
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1026

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.List;
 
 /** An exception thrown by an RPC client to indicate remote/server-side failure. */
-public final class RemoteException extends RuntimeException implements SafeLoggable {
+public final class RemoteException extends RuntimeException implements SafeLoggable, ResponseStatus {
     private static final long serialVersionUID = 1L;
     private static final String ERROR_INSTANCE_ID = "errorInstanceId";
     private static final String ERROR_CODE = "errorCode";
@@ -44,6 +44,7 @@ public final class RemoteException extends RuntimeException implements SafeLogga
     }
 
     /** The HTTP status code of the HTTP response conveying the remote exception. */
+    @Override
     public int getStatus() {
         return status;
     }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ResponseStatus.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ResponseStatus.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+public interface ResponseStatus {
+    /** The HTTP status code of the HTTP response conveying the error. */
+    int getStatus();
+}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/UnknownRemoteException.java
@@ -20,18 +20,17 @@ import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.UnsafeArg;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /** An exception thrown by an RPC client to indicate remote/server-side failure from a non-remoting server. */
-public final class UnknownRemoteException extends RuntimeException implements SafeLoggable {
+public final class UnknownRemoteException extends RuntimeException implements SafeLoggable, ResponseStatus {
     private static final long serialVersionUID = 1L;
 
     private final int status;
     private final String body;
 
     /** The HTTP status code of the HTTP response conveying the error. */
+    @Override
     public int getStatus() {
         return status;
     }
@@ -54,9 +53,6 @@ public final class UnknownRemoteException extends RuntimeException implements Sa
 
     @Override
     public List<Arg<?>> getArgs() {
-        List<Arg<?>> args = new ArrayList<>(2);
-        args.add(SafeArg.of("status", getStatus()));
-        args.add(UnsafeArg.of("body", getBody()));
-        return Collections.unmodifiableList(args);
+        return List.of(SafeArg.of("status", getStatus()), UnsafeArg.of("body", getBody()));
     }
 }


### PR DESCRIPTION
## Before this PR
Consumers that handle `UnknownRemoteException` and `RemoteException` via `getStatus()` often require duplicative code paths because there is not a shared interface to retrieve the HTTP response codes.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
(Unknown)RemoteException implement ResponseStatus
==COMMIT_MSG==

## Possible downsides?
We already expose `getStatus()` as public API on both exception types, but do we want to expose this interface as super type?

