### PR TITLE
Avoid deprecated mappingException with SafeJsonMappingException

### DIFF
--- a/changelog/@unreleased/pr-1041.v2.yml
+++ b/changelog/@unreleased/pr-1041.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Replace deprecated mappingException
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1041

--- a/extras/jackson-support/build.gradle
+++ b/extras/jackson-support/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     api "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
 
+    implementation "com.palantir.safe-logging:safe-logging"
+
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation "org.assertj:assertj-core"
 }

--- a/extras/jackson-support/src/main/java/com/palantir/conjure/java/api/ext/jackson/PathDeserializer.java
+++ b/extras/jackson-support/src/main/java/com/palantir/conjure/java/api/ext/jackson/PathDeserializer.java
@@ -19,10 +19,15 @@ package com.palantir.conjure.java.api.ext.jackson;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 public final class PathDeserializer extends StdScalarDeserializer<Path> {
     private static final long serialVersionUID = 1;
@@ -40,6 +45,26 @@ public final class PathDeserializer extends StdScalarDeserializer<Path> {
             }
             // 16-Oct-2015: should we perhaps allow JSON Arrays (of Strings) as well?
         }
-        throw ctxt.mappingException(Path.class, token);
+        throw new SafeJsonMappingException(
+                "Could not deserialize path", parser, ctxt.wrongTokenException(parser, Path.class, token, null));
+    }
+
+    private static final class SafeJsonMappingException extends JsonMappingException implements SafeLoggable {
+        private final String logMessage;
+
+        SafeJsonMappingException(@CompileTimeConstant String message, JsonParser parser, JsonMappingException cause) {
+            super(parser, message, cause);
+            this.logMessage = message;
+        }
+
+        @Override
+        public String getLogMessage() {
+            return logMessage;
+        }
+
+        @Override
+        public List<Arg<?>> getArgs() {
+            return List.of();
+        }
     }
 }


### PR DESCRIPTION
## Before this PR
Jackson deprecated `DeserializationContext#mappingException` and removes it in 2.16, leading to compilation failure in https://github.com/palantir/conjure-java-runtime-api/pull/1040

## After this PR
==COMMIT_MSG==
Replace deprecated mappingException
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

