### PR TITLE
Fix RawTypes warning in QosExceptionTest

### DIFF
--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java
@@ -30,19 +30,19 @@ public final class QosExceptionTest {
 
     @Test
     public void testVisitorSanity() throws Exception {
-        QosException.Visitor<Class> visitor = new QosException.Visitor<Class>() {
+        QosException.Visitor<Class<?>> visitor = new QosException.Visitor<>() {
             @Override
-            public Class visit(QosException.Throttle exception) {
+            public Class<?> visit(QosException.Throttle exception) {
                 return exception.getClass();
             }
 
             @Override
-            public Class visit(QosException.RetryOther exception) {
+            public Class<?> visit(QosException.RetryOther exception) {
                 return exception.getClass();
             }
 
             @Override
-            public Class visit(QosException.Unavailable exception) {
+            public Class<?> visit(QosException.Unavailable exception) {
                 return exception.getClass();
             }
         };


### PR DESCRIPTION
## Before this PR
Warnings emitted while compiling this class:
```
/Volumes/git/conjure-java-runtime-api/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java:33: warning: [RawTypes] Avoid raw types; add appropriate type parameters if possible. The type was: Class
        QosException.Visitor<Class> visitor = new QosException.Visitor<Class>() {
                             ^
  This can be suppressed with @SuppressWarnings("rawtypes") where necessary, such as when interacting with older library code.
    (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
/Volumes/git/conjure-java-runtime-api/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java:33: warning: [RawTypes] Avoid raw types; add appropriate type parameters if possible. The type was: Class
        QosException.Visitor<Class> visitor = new QosException.Visitor<Class>() {
                                                                       ^
  This can be suppressed with @SuppressWarnings("rawtypes") where necessary, such as when interacting with older library code.
    (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
/Volumes/git/conjure-java-runtime-api/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java:33: warning: [RawTypes] Avoid raw types; add appropriate type parameters if possible. The type was: Class
        QosException.Visitor<Class> visitor = new QosException.Visitor<Class>() {
                                                                       ^
  This can be suppressed with @SuppressWarnings("rawtypes") where necessary, such as when interacting with older library code.
    (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
/Volumes/git/conjure-java-runtime-api/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java:35: warning: [RawTypes] Avoid raw types; add appropriate type parameters if possible. The type was: Class
            public Class visit(QosException.Throttle exception) {
                   ^
  This can be suppressed with @SuppressWarnings("rawtypes") where necessary, such as when interacting with older library code.
    (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
/Volumes/git/conjure-java-runtime-api/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java:40: warning: [RawTypes] Avoid raw types; add appropriate type parameters if possible. The type was: Class
            public Class visit(QosException.RetryOther exception) {
                   ^
  This can be suppressed with @SuppressWarnings("rawtypes") where necessary, such as when interacting with older library code.
    (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
/Volumes/git/conjure-java-runtime-api/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java:45: warning: [RawTypes] Avoid raw types; add appropriate type parameters if possible. The type was: Class
            public Class visit(QosException.Unavailable exception) {
                   ^
  This can be suppressed with @SuppressWarnings("rawtypes") where necessary, such as when interacting with older library code.
    (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
6 warnings
```

## After this PR
==COMMIT_MSG==
Fix RawTypes warning in QosExceptionTest
==COMMIT_MSG==

## Possible downsides?
None known, especially since this is a test-only change