### PR TITLE
Test coverage for SerializableError.forException() with Optional values

### DIFF
--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
@@ -26,6 +26,7 @@ import com.palantir.logsafe.UnsafeArg;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
@@ -123,6 +124,24 @@ public final class SerializableErrorTest {
                         value ->
                                 // Example: [Ljava.lang.String;@769a49e3
                                 assertThat(value).matches(Pattern.quote("[Ljava.lang.String;@") + "[0-9a-f]+"));
+    }
+
+    @Test
+    public void forException_optionalArgValue_serializesWithToString() {
+        ErrorType error = ErrorType.INTERNAL;
+        ServiceException exception = new ServiceException(
+                error,
+                SafeArg.of("safe-optional-present", Optional.of("hello")),
+                UnsafeArg.of("unsafe-optional-empty", Optional.empty()));
+
+        SerializableError expected = new SerializableError.Builder()
+                .errorCode(error.code().name())
+                .errorName(error.name())
+                .errorInstanceId(exception.getErrorInstanceId())
+                .putParameters("safe-optional-present", "Optional[hello]")
+                .putParameters("unsafe-optional-empty", "Optional.empty")
+                .build();
+        assertThat(SerializableError.forException(exception)).isEqualTo(expected);
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/conjure-java-runtime-api/pull/1048 added test coverage for list, map, and array.  But it did not cover optional, which is a common parameter value types.

## After this PR
==COMMIT_MSG==
Test coverage for SerializableError.forException() with Optional values
==COMMIT_MSG==

## Possible downsides?
None known -- this is a test-only change