### PR TITLE
Make SerializableError.errorName @Safe by replacing messages with a fixed error name

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/RemoteException.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.api.errors;
 
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.Unsafe;
@@ -32,7 +33,7 @@ public final class RemoteException extends RuntimeException implements SafeLogga
     private static final String ERROR_CODE = "errorCode";
     private static final String ERROR_NAME = "errorName";
 
-    @Unsafe // because errorName is unsafe
+    @Safe
     private final String stableMessage;
 
     private final SerializableError error;
@@ -96,7 +97,7 @@ public final class RemoteException extends RuntimeException implements SafeLogga
         return builder.toString();
     }
 
-    @Unsafe
+    @Safe
     @Override
     public String getLogMessage() {
         return stableMessage;

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -65,11 +65,12 @@ public abstract class SerializableError implements Serializable {
      * {@link ErrorType#name} and is part of the service's API surface. Clients are given access to the service-side
      * error name via {@link RemoteException#getError} and typically switch&dispatch on the error code and/or name.
      */
-    @Unsafe // because message is unsafe
+    @Safe
     @JsonProperty("errorName")
     @Value.Default
     public String errorName() {
         return getMessage()
+                .map(_unsafeMessage -> "Default:EmptyErrorNameWithLegacyMessageUsage")
                 .orElseThrow(() -> new SafeIllegalStateException("Expected either 'errorName' or 'message' to be set"));
     }
 

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
@@ -171,13 +171,13 @@ public final class SerializableErrorTest {
     }
 
     @Test
-    public void testLegacyMessageUsedAsErrorNameWhenNoErrorNameIsSet() {
+    public void testLegacyMessageWhenNoErrorNameIsSetUsesDefaultErrorName() {
         SerializableError error = SerializableError.builder()
                 .errorCode("errorCode")
                 .message("the secret is 42")
                 .build();
 
-        assertThat(error.errorName()).isEqualTo("the secret is 42");
+        assertThat(error.errorName()).isEqualTo("Default:EmptyErrorNameWithLegacyMessageUsage");
     }
 
     @Test


### PR DESCRIPTION
An amendment to https://github.com/palantir/conjure-java-runtime-api/pull/1053 that resolves the issue mentioned at https://github.com/palantir/conjure-java-runtime-api/pull/1053#discussion_r1384224440