### PR TITLE
Relax ErrorType namespace restrictions

### DIFF
--- a/changelog/@unreleased/pr-1056.v2.yml
+++ b/changelog/@unreleased/pr-1056.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`ErrorType.create` no longer prevents creating `ErrorType` values
+    in the `Default` namespace.'
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1056

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
@@ -16,7 +16,8 @@
 
 package com.palantir.conjure.java.api.errors;
 
-import java.util.regex.Matcher;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.regex.Pattern;
 import org.immutables.value.Value;
 
@@ -55,18 +56,16 @@ public abstract class ErrorType {
         }
     }
 
-    public static final ErrorType UNAUTHORIZED = createInternal(Code.UNAUTHORIZED, "Default:Unauthorized");
-    public static final ErrorType PERMISSION_DENIED =
-            createInternal(Code.PERMISSION_DENIED, "Default:PermissionDenied");
-    public static final ErrorType INVALID_ARGUMENT = createInternal(Code.INVALID_ARGUMENT, "Default:InvalidArgument");
+    public static final ErrorType UNAUTHORIZED = create(Code.UNAUTHORIZED, "Default:Unauthorized");
+    public static final ErrorType PERMISSION_DENIED = create(Code.PERMISSION_DENIED, "Default:PermissionDenied");
+    public static final ErrorType INVALID_ARGUMENT = create(Code.INVALID_ARGUMENT, "Default:InvalidArgument");
     public static final ErrorType REQUEST_ENTITY_TOO_LARGE =
-            createInternal(Code.REQUEST_ENTITY_TOO_LARGE, "Default:RequestEntityTooLarge");
-    public static final ErrorType NOT_FOUND = createInternal(Code.NOT_FOUND, "Default:NotFound");
-    public static final ErrorType CONFLICT = createInternal(Code.CONFLICT, "Default:Conflict");
-    public static final ErrorType FAILED_PRECONDITION =
-            createInternal(Code.FAILED_PRECONDITION, "Default:FailedPrecondition");
-    public static final ErrorType INTERNAL = createInternal(Code.INTERNAL, "Default:Internal");
-    public static final ErrorType TIMEOUT = createInternal(Code.TIMEOUT, "Default:Timeout");
+            create(Code.REQUEST_ENTITY_TOO_LARGE, "Default:RequestEntityTooLarge");
+    public static final ErrorType NOT_FOUND = create(Code.NOT_FOUND, "Default:NotFound");
+    public static final ErrorType CONFLICT = create(Code.CONFLICT, "Default:Conflict");
+    public static final ErrorType FAILED_PRECONDITION = create(Code.FAILED_PRECONDITION, "Default:FailedPrecondition");
+    public static final ErrorType INTERNAL = create(Code.INTERNAL, "Default:Internal");
+    public static final ErrorType TIMEOUT = create(Code.TIMEOUT, "Default:Timeout");
 
     /** The {@link Code} of this error. */
     public abstract Code code();
@@ -83,32 +82,14 @@ public abstract class ErrorType {
     @Value.Check
     final void check() {
         if (!ERROR_NAME_PATTERN.matcher(name()).matches()) {
-            throw new IllegalArgumentException(
-                    "ErrorType names must be of the form 'UpperCamelNamespace:UpperCamelName': " + name());
+            throw new SafeIllegalArgumentException(
+                    "ErrorType names must be of the form 'UpperCamelNamespace:UpperCamelName'",
+                    SafeArg.of("name", name()));
         }
     }
 
     /** Constructs an {@link ErrorType} with the given error {@link Code} and name. */
     public static ErrorType create(Code code, String name) {
-        return createAndCheckNamespaceIsNotDefault(code, name);
-    }
-
-    private static ErrorType createAndCheckNamespaceIsNotDefault(Code code, String name) {
-        ErrorType error = createInternal(code, name);
-        Matcher matcher = ERROR_NAME_PATTERN.matcher(name);
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException("Expected ERROR_NAME_PATTERN to match, this is a bug: " + name);
-        }
-
-        String namespace = matcher.group(1);
-        if (namespace.equals("Default")) {
-            throw new IllegalArgumentException("Namespace must not be 'Default' in ErrorType name: " + name);
-        }
-
-        return error;
-    }
-
-    private static ErrorType createInternal(Code code, String name) {
         return ImmutableErrorType.builder()
                 .code(code)
                 .name(name)

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ErrorTypeTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ErrorTypeTest.java
@@ -16,9 +16,12 @@
 
 package com.palantir.conjure.java.api.errors;
 
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.conjure.java.api.errors.ErrorType.Code;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import org.junit.jupiter.api.Test;
 
 public final class ErrorTypeTest {
@@ -27,15 +30,18 @@ public final class ErrorTypeTest {
     public void testNameMustBeCamelCaseWithOptionalNameSpace() throws Exception {
         String[] badNames = new String[] {":", "foo:Bar", ":Bar", "Bar:", "foo:bar", "Foo:bar", "Foo:2Bar"};
         for (String name : badNames) {
-            assertThatThrownBy(() -> ErrorType.create(ErrorType.Code.CUSTOM_CLIENT, name))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("ErrorType names must be of the form 'UpperCamelNamespace:UpperCamelName': %s", name);
-            assertThatThrownBy(() -> ErrorType.create(ErrorType.Code.CUSTOM_SERVER, name))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("ErrorType names must be of the form 'UpperCamelNamespace:UpperCamelName': %s", name);
-            assertThatThrownBy(() -> ErrorType.create(ErrorType.Code.FAILED_PRECONDITION, name))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("ErrorType names must be of the form 'UpperCamelNamespace:UpperCamelName': %s", name);
+            assertThatLoggableExceptionThrownBy(() -> ErrorType.create(Code.CUSTOM_CLIENT, name))
+                    .isInstanceOf(SafeIllegalArgumentException.class)
+                    .hasLogMessage("ErrorType names must be of the form 'UpperCamelNamespace:UpperCamelName'")
+                    .hasExactlyArgs(SafeArg.of("name", name));
+            assertThatLoggableExceptionThrownBy(() -> ErrorType.create(ErrorType.Code.CUSTOM_SERVER, name))
+                    .isInstanceOf(SafeIllegalArgumentException.class)
+                    .hasLogMessage("ErrorType names must be of the form 'UpperCamelNamespace:UpperCamelName'")
+                    .hasExactlyArgs(SafeArg.of("name", name));
+            assertThatLoggableExceptionThrownBy(() -> ErrorType.create(ErrorType.Code.FAILED_PRECONDITION, name))
+                    .isInstanceOf(SafeIllegalArgumentException.class)
+                    .hasLogMessage("ErrorType names must be of the form 'UpperCamelNamespace:UpperCamelName'")
+                    .hasExactlyArgs(SafeArg.of("name", name));
         }
 
         String[] goodNames = new String[] {"Foo:Bar", "FooBar:Baz", "FooBar:BoomBang", "Foo:Bar2Baz3"};
@@ -44,19 +50,6 @@ public final class ErrorTypeTest {
             ErrorType.create(ErrorType.Code.CUSTOM_SERVER, name);
             ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, name);
         }
-    }
-
-    @Test
-    public void testNamespaceMustNotBeDefault() throws Exception {
-        assertThatThrownBy(() -> ErrorType.create(ErrorType.Code.CUSTOM_SERVER, "Default:Foo"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Namespace must not be 'Default' in ErrorType name: Default:Foo");
-        assertThatThrownBy(() -> ErrorType.create(ErrorType.Code.CUSTOM_SERVER, "Default:Foo"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Namespace must not be 'Default' in ErrorType name: Default:Foo");
-        assertThatThrownBy(() -> ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "Default:Foo"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Namespace must not be 'Default' in ErrorType name: Default:Foo");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
`ErrorType.create` cannot be used to create errors in the `Default` namespace.

This is problematic for endpoints that proxy requests and want to pass through any errors unchanged. We have a couple places internally with code that looks like this:

```java
try {
    // Proxy request
} catch (RemoteException exception) {
    SerializableError error = exception.getError();
    ErrorType.Code errorCode = ErrorType.Code.valueOf(error.errorCode());
    Arg<?>[] args = EntryStream.of(error.parameters())
            .mapKeyValue(UnsafeArg::of)
            .toArray(Arg[]::new);

    throw new ServiceException(ErrorType.create(errorCode, error.errorName()), exception, args);
}
```

I have recently realized that this is broken and the proxied requests end up failing with `Default:InvalidArgument` here  due to this restriction in `ErrorType.create`.

## After this PR
`ErrorType.create` can be used to create errors in the `Default` namespace.

## Possible downsides?

Is there some value to having this restriction?
