### PR TITLE
Make QosException, ErrorType Serializable

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ErrorType.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.api.errors;
 
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.io.Serializable;
 import java.util.regex.Pattern;
 import org.immutables.value.Value;
 
@@ -29,7 +30,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutablesStyle
-public abstract class ErrorType {
+public abstract class ErrorType implements Serializable {
 
     private static final String UPPER_CAMEL_CASE = "(([A-Z][a-z0-9]+)+)";
     // UpperCamel with UpperCamel namespace prefix.

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
@@ -183,16 +183,16 @@ public abstract class QosException extends RuntimeException {
     public static final class Throttle extends QosException implements SafeLoggable {
         private static final QosReason DEFAULT_REASON = QosReason.of("qos-throttle");
 
-        private final Optional<Duration> retryAfter;
+        private final Duration retryAfter;
 
         private Throttle(Optional<Duration> retryAfter) {
             super("Suggesting request throttling with optional retryAfter duration: " + retryAfter, DEFAULT_REASON);
-            this.retryAfter = retryAfter;
+            this.retryAfter = retryAfter.orElse(null);
         }
 
         private Throttle(Optional<Duration> retryAfter, QosReason reason) {
             super("Suggesting request throttling with optional retryAfter duration: " + retryAfter, reason);
-            this.retryAfter = retryAfter;
+            this.retryAfter = retryAfter.orElse(null);
         }
 
         private Throttle(Optional<Duration> retryAfter, Throwable cause) {
@@ -200,16 +200,16 @@ public abstract class QosException extends RuntimeException {
                     "Suggesting request throttling with optional retryAfter duration: " + retryAfter,
                     cause,
                     DEFAULT_REASON);
-            this.retryAfter = retryAfter;
+            this.retryAfter = retryAfter.orElse(null);
         }
 
         private Throttle(Optional<Duration> retryAfter, Throwable cause, QosReason reason) {
             super("Suggesting request throttling with optional retryAfter duration: " + retryAfter, cause, reason);
-            this.retryAfter = retryAfter;
+            this.retryAfter = retryAfter.orElse(null);
         }
 
         public Optional<Duration> getRetryAfter() {
-            return retryAfter;
+            return Optional.ofNullable(retryAfter);
         }
 
         @Override
@@ -224,7 +224,7 @@ public abstract class QosException extends RuntimeException {
 
         @Override
         public List<Arg<?>> getArgs() {
-            return List.of(SafeArg.of("retryAfter", retryAfter.orElse(null)), SafeArg.of("reason", getReason()));
+            return List.of(SafeArg.of("retryAfter", retryAfter), SafeArg.of("reason", getReason()));
         }
     }
 

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.api.errors;
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -30,7 +31,7 @@ import java.util.regex.Pattern;
  * tag, for observability into {@link QosException} calls. As such, the string is constrained to have at most 50
  * lowercase alphanumeric characters, and hyphens (-).
  */
-public final class QosReason {
+public final class QosReason implements Serializable {
 
     @CompileTimeConstant
     private final String reason;


### PR DESCRIPTION
## Before this PR

`QosException`s aren't serializable even though they transitively `implements Serializable` due to the fact that they contain fields that aren't `Serializable` (`QosReason`, `Optional<Duration>` in `Throttle`).

Similarly `ErrorType` does not implement `Serializable`.

This isn't a problem in most cases, however when using Spark this becomes an issue when an executor encounters an exception that's not `Serializable` as it means that it can't be propagated back to the driver:

https://github.com/apache/spark/blob/4221c66919d950342134b9490d288c5f1ba66135/core/src/main/scala/org/apache/spark/executor/Executor.scala#L811-L823

Which in turns makes debugging quite a bit harder, therefore we should strive to support java's `Serializable`.

## After this PR

==COMMIT_MSG==
Make QosException, ErrorType Serializable
==COMMIT_MSG==

