### PR TITLE
Expose InstaceOfAssertFactory for exception asserts

### DIFF
--- a/changelog/@unreleased/pr-1074.v2.yml
+++ b/changelog/@unreleased/pr-1074.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: '`ServiceExceptionAssert`, `RemoteExceptionAssert`, and `QosExceptionAssert`
+    expose a static `instanceOfFactoryAssert` method which provides an `InstanceOfAssertFactory`
+    that can be used to downcast these types in assertions using `asInstanceOf`.'
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1074

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
@@ -19,7 +19,6 @@ package com.palantir.conjure.java.api.testing;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
-import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
@@ -43,43 +42,16 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     @CanIgnoreReturnValue
     public static ServiceExceptionAssert assertThatServiceExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
-        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(ServiceExceptionInstanceOfAssertFactory.INSTANCE);
+        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(ServiceExceptionAssert.instanceOfAssertFactory());
     }
 
     @CanIgnoreReturnValue
     public static RemoteExceptionAssert assertThatRemoteExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
-        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(RemoteExceptionInstanceOfAssertFactory.INSTANCE);
+        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(RemoteExceptionAssert.instanceOfAssertFactory());
     }
 
     @CanIgnoreReturnValue
     public static QosExceptionAssert assertThatQosExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
-        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(QosExceptionInstanceOfAssertFactory.INSTANCE);
-    }
-
-    private static final class ServiceExceptionInstanceOfAssertFactory
-            extends InstanceOfAssertFactory<ServiceException, ServiceExceptionAssert> {
-        static final ServiceExceptionInstanceOfAssertFactory INSTANCE = new ServiceExceptionInstanceOfAssertFactory();
-
-        ServiceExceptionInstanceOfAssertFactory() {
-            super(ServiceException.class, ServiceExceptionAssert::new);
-        }
-    }
-
-    private static final class RemoteExceptionInstanceOfAssertFactory
-            extends InstanceOfAssertFactory<RemoteException, RemoteExceptionAssert> {
-        static final RemoteExceptionInstanceOfAssertFactory INSTANCE = new RemoteExceptionInstanceOfAssertFactory();
-
-        RemoteExceptionInstanceOfAssertFactory() {
-            super(RemoteException.class, RemoteExceptionAssert::new);
-        }
-    }
-
-    private static final class QosExceptionInstanceOfAssertFactory
-            extends InstanceOfAssertFactory<QosException, QosExceptionAssert> {
-        static final QosExceptionInstanceOfAssertFactory INSTANCE = new QosExceptionInstanceOfAssertFactory();
-
-        QosExceptionInstanceOfAssertFactory() {
-            super(QosException.class, QosExceptionAssert::new);
-        }
+        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(QosExceptionAssert.instanceOfAssertFactory());
     }
 }

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/QosExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/QosExceptionAssert.java
@@ -20,11 +20,19 @@ import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.QosReason;
 import java.util.Objects;
 import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
 
 public class QosExceptionAssert extends AbstractThrowableAssert<QosExceptionAssert, QosException> {
 
+    private static final InstanceOfAssertFactory<QosException, QosExceptionAssert> INSTANCE_OF_ASSERT_FACTORY =
+            new InstanceOfAssertFactory<>(QosException.class, QosExceptionAssert::new);
+
     QosExceptionAssert(QosException actual) {
         super(actual, QosExceptionAssert.class);
+    }
+
+    public static InstanceOfAssertFactory<QosException, QosExceptionAssert> instanceOfAssertFactory() {
+        return INSTANCE_OF_ASSERT_FACTORY;
     }
 
     public final QosExceptionAssert hasReason(QosReason reason) {

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/RemoteExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/RemoteExceptionAssert.java
@@ -20,12 +20,20 @@ import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import java.util.Objects;
 import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.util.Throwables;
 
 public class RemoteExceptionAssert extends AbstractThrowableAssert<RemoteExceptionAssert, RemoteException> {
 
+    private static final InstanceOfAssertFactory<RemoteException, RemoteExceptionAssert> INSTANCE_OF_ASSERT_FACTORY =
+            new InstanceOfAssertFactory<>(RemoteException.class, RemoteExceptionAssert::new);
+
     RemoteExceptionAssert(RemoteException actual) {
         super(actual, RemoteExceptionAssert.class);
+    }
+
+    public static InstanceOfAssertFactory<RemoteException, RemoteExceptionAssert> instanceOfAssertFactory() {
+        return INSTANCE_OF_ASSERT_FACTORY;
     }
 
     public final RemoteExceptionAssert isGeneratedFromErrorType(ErrorType type) {

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
@@ -25,12 +25,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.util.Throwables;
 
 public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExceptionAssert, ServiceException> {
 
+    private static final InstanceOfAssertFactory<ServiceException, ServiceExceptionAssert> INSTANCE_OF_ASSERT_FACTORY =
+            new InstanceOfAssertFactory<>(ServiceException.class, ServiceExceptionAssert::new);
+
     ServiceExceptionAssert(ServiceException actual) {
         super(actual, ServiceExceptionAssert.class);
+    }
+
+    public static InstanceOfAssertFactory<ServiceException, ServiceExceptionAssert> instanceOfAssertFactory() {
+        return INSTANCE_OF_ASSERT_FACTORY;
     }
 
     public final ServiceExceptionAssert hasType(ErrorType type) {


### PR DESCRIPTION
## Before this PR

It's awkward to write assertions when you have a generic `RuntimeException` and want to use one of the exception asserts provided here.

AssertJ provides an `asInstanceOf` method to downcast a value and construct an specific assert class. We have implementations of `InstanceOfAssertFactory` but they are not exposed to consumers. 

## After this PR

Expose methods that provide a `InstanceOfAssertFactory` so that consumers can perform the downcasting themselves using the `asInstanceOf` method.

