### PR TITLE
Be more lenient when deserializing error parameters

### DIFF
--- a/changelog/@unreleased/pr-1085.v2.yml
+++ b/changelog/@unreleased/pr-1085.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: 'Be more lenient when deserializing error parameters'
+  description: Be more lenient when deserializing error parameters.
   links:
   - https://github.com/palantir/conjure-java-runtime-api/pull/1085

--- a/changelog/@unreleased/pr-1085.v2.yml
+++ b/changelog/@unreleased/pr-1085.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: 'Be more lenient when deserializing error parameters'
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1085

--- a/changelog/@unreleased/pr-1085.v2.yml
+++ b/changelog/@unreleased/pr-1085.v2.yml
@@ -1,5 +1,5 @@
-type: feature
-feature:
+type: improvement
+improvement:
   description: 'Be more lenient when deserializing error parameters'
   links:
   - https://github.com/palantir/conjure-java-runtime-api/pull/1085

--- a/changelog/@unreleased/pr-1085.v2.yml
+++ b/changelog/@unreleased/pr-1085.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-improvement:
-  description: Be more lenient when deserializing error parameters.
-  links:
-  - https://github.com/palantir/conjure-java-runtime-api/pull/1085

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -87,7 +87,7 @@ public abstract class SerializableError implements Serializable {
     }
 
     /** A set of parameters that further explain the error. */
-    @JsonDeserialize(contentUsing = ParametersDeserializer.class)
+    @JsonDeserialize(contentUsing = ParameterDeserializer.class)
     public abstract Map<String, String> parameters();
 
     /**
@@ -136,7 +136,7 @@ public abstract class SerializableError implements Serializable {
         return new Builder();
     }
 
-    static class ParametersDeserializer extends JsonDeserializer<String> {
+    protected static final class ParameterDeserializer extends JsonDeserializer<String> {
 
         @Override
         public String deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -21,15 +21,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -89,7 +86,7 @@ public abstract class SerializableError implements Serializable {
     }
 
     /** A set of parameters that further explain the error. */
-    @JsonDeserialize(using = ParametersDeserializer.class)
+    @JsonDeserialize(contentUsing = ParametersDeserializer.class)
     public abstract Map<String, String> parameters();
 
     /**
@@ -138,20 +135,11 @@ public abstract class SerializableError implements Serializable {
         return new Builder();
     }
 
-    static class ParametersDeserializer extends JsonDeserializer<Map<String, String>> {
+    static class ParametersDeserializer extends JsonDeserializer<String> {
 
         @Override
-        public Map<String, String> deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {
-            Map<String, String> resultMap = new HashMap<>();
-            JsonNode rootNode = parser.getCodec().readTree(parser);
-            Iterator<Map.Entry<String, JsonNode>> fieldsIterator = rootNode.fields();
-
-            while (fieldsIterator.hasNext()) {
-                Map.Entry<String, JsonNode> field = fieldsIterator.next();
-                resultMap.put(field.getKey(), field.getValue().toString());
-            }
-
-            return resultMap;
+        public String deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {
+            return parser.readValueAsTree().toString();
         }
     }
 }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.logsafe.Arg;
@@ -139,7 +140,13 @@ public abstract class SerializableError implements Serializable {
 
         @Override
         public String deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {
-            return parser.readValueAsTree().toString();
+            JsonNode node = parser.readValueAsTree();
+            String textValue = node.textValue();
+            if (textValue != null) {
+                return textValue;
+            } else {
+                return node.toString();
+            }
         }
     }
 }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -136,7 +136,7 @@ public abstract class SerializableError implements Serializable {
         return new Builder();
     }
 
-    protected static final class ParameterDeserializer extends JsonDeserializer<String> {
+    static final class ParameterDeserializer extends JsonDeserializer<String> {
 
         @Override
         public String deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
@@ -237,6 +237,17 @@ public final class SerializableErrorTest {
                         .build());
     }
 
+    @Test
+    public void testDeserializeWithJsonStringParameters() throws Exception {
+        String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
+                + "\"parameters\":{\"key\":\"value\"}}";
+        assertThat(deserialize(serialized))
+                .isEqualTo(SerializableError.builder()
+                        .from(ERROR)
+                        .putParameters("key", "value")
+                        .build());
+    }
+
     private static SerializableError deserialize(String serialized) throws IOException {
         return mapper.readValue(serialized, SerializableError.class);
     }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
@@ -193,6 +193,17 @@ public final class SerializableErrorTest {
                 .hasNoArgs();
     }
 
+    @Test
+    public void testDeserializeWithJsonParameters() throws Exception {
+        String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
+                + "\"parameters\":{\"key\":{\"nested\": \"value\"}}}";
+        assertThat(deserialize(serialized))
+                .isEqualTo(SerializableError.builder()
+                        .from(ERROR)
+                        .putParameters("key", "{\"nested\":\"value\"}")
+                        .build());
+    }
+
     private static SerializableError deserialize(String serialized) throws IOException {
         return mapper.readValue(serialized, SerializableError.class);
     }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
@@ -194,7 +194,7 @@ public final class SerializableErrorTest {
     }
 
     @Test
-    public void testDeserializeWithJsonObjectParameters() throws Exception {
+    public void testDeserializeWithJsonObjectParameter() throws Exception {
         String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
                 + "\"parameters\":{\"key\":{\"nested\": \"value\"}}}";
         assertThat(deserialize(serialized))
@@ -205,7 +205,7 @@ public final class SerializableErrorTest {
     }
 
     @Test
-    public void testDeserializeWithJsonArrayParameters() throws Exception {
+    public void testDeserializeWithJsonArrayParameter() throws Exception {
         String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
                 + "\"parameters\":{\"key\":[\"nested\"]}}";
         assertThat(deserialize(serialized))
@@ -216,7 +216,7 @@ public final class SerializableErrorTest {
     }
 
     @Test
-    public void testDeserializeWithJsonBooleanParameters() throws Exception {
+    public void testDeserializeWithJsonBooleanParameter() throws Exception {
         String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
                 + "\"parameters\":{\"key\":true}}";
         assertThat(deserialize(serialized))
@@ -227,7 +227,7 @@ public final class SerializableErrorTest {
     }
 
     @Test
-    public void testDeserializeWithJsonNumberParameters() throws Exception {
+    public void testDeserializeWithJsonNumberParameter() throws Exception {
         String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
                 + "\"parameters\":{\"key\":1.1}}";
         assertThat(deserialize(serialized))
@@ -238,7 +238,7 @@ public final class SerializableErrorTest {
     }
 
     @Test
-    public void testDeserializeWithJsonStringParameters() throws Exception {
+    public void testDeserializeWithJsonStringParameter() throws Exception {
         String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
                 + "\"parameters\":{\"key\":\"value\"}}";
         assertThat(deserialize(serialized))

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
@@ -194,13 +194,46 @@ public final class SerializableErrorTest {
     }
 
     @Test
-    public void testDeserializeWithJsonParameters() throws Exception {
+    public void testDeserializeWithJsonObjectParameters() throws Exception {
         String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
                 + "\"parameters\":{\"key\":{\"nested\": \"value\"}}}";
         assertThat(deserialize(serialized))
                 .isEqualTo(SerializableError.builder()
                         .from(ERROR)
                         .putParameters("key", "{\"nested\":\"value\"}")
+                        .build());
+    }
+
+    @Test
+    public void testDeserializeWithJsonArrayParameters() throws Exception {
+        String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
+                + "\"parameters\":{\"key\":[\"nested\"]}}";
+        assertThat(deserialize(serialized))
+                .isEqualTo(SerializableError.builder()
+                        .from(ERROR)
+                        .putParameters("key", "[\"nested\"]")
+                        .build());
+    }
+
+    @Test
+    public void testDeserializeWithJsonBooleanParameters() throws Exception {
+        String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
+                + "\"parameters\":{\"key\":true}}";
+        assertThat(deserialize(serialized))
+                .isEqualTo(SerializableError.builder()
+                        .from(ERROR)
+                        .putParameters("key", "true")
+                        .build());
+    }
+
+    @Test
+    public void testDeserializeWithJsonNumberParameters() throws Exception {
+        String serialized = "{\"errorCode\":\"PERMISSION_DENIED\",\"errorName\":\"Product:SomethingBroke\","
+                + "\"parameters\":{\"key\":1.1}}";
+        assertThat(deserialize(serialized))
+                .isEqualTo(SerializableError.builder()
+                        .from(ERROR)
+                        .putParameters("key", "1.1")
                         .build());
     }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`conjure-java` expects the error parameters to be a `Map<String, String>`, but `conjure-go-runtime` is serializing it as `Map<String, Object>`. If a conjure Go service throws an error with parameters that cannot be deserialized as `Map<String, String>`, deserialization will fail and the java service will throw an `UnknownRemoteException`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
We accept `Map<String, Object>` for parameters and keep stringified values in the deserialized `Map<String, String>`

==COMMIT_MSG==
Be more lenient when deserializing error parameters
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

