### PR TITLE
Immutables value annotations should be an API dep

### DIFF
--- a/errors/build.gradle
+++ b/errors/build.gradle
@@ -17,5 +17,5 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     annotationProcessor "org.immutables:value"
-    compileOnly 'org.immutables:value::annotations'
+    api 'org.immutables:value::annotations'
 }

--- a/errors/build.gradle
+++ b/errors/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind"
     api "com.google.code.findbugs:jsr305"
     api "com.palantir.safe-logging:safe-logging"
+    api 'org.immutables:value::annotations'
     api "org.jetbrains:annotations"
     implementation "com.palantir.safe-logging:preconditions"
 
@@ -17,5 +18,4 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     annotationProcessor "org.immutables:value"
-    api 'org.immutables:value::annotations'
 }


### PR DESCRIPTION
## Before this PR
Some projects that depended on `errors` are failing to upgrade automatically because they cannot find this dep.

`(/com/palantir/conjure/java/api/errors/ErrorType.class): warning: Cannot find annotation method 'builder()' in type 'Immutable': class file for org.immutables.value.Value not found`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

