### PR TITLE
Add ServiceExceptionAssert.hasCode

### DIFF
--- a/changelog/@unreleased/pr-1103.v2.yml
+++ b/changelog/@unreleased/pr-1103.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Add `ServiceExceptionAssert.hasCode` to assert the `ErrorType.Code`
+    of a `ServiceException`.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1103

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
@@ -41,6 +41,14 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         return INSTANCE_OF_ASSERT_FACTORY;
     }
 
+    public final ServiceExceptionAssert hasCode(ErrorType.Code code) {
+        isNotNull();
+        failIfNotEqual(
+                "Expected ErrorType.Code to be %s, but found %s",
+                code, actual.getErrorType().code());
+        return this;
+    }
+
     public final ServiceExceptionAssert hasType(ErrorType type) {
         isNotNull();
         failIfNotEqual("Expected ErrorType to be %s, but found %s", type, actual.getErrorType());

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
@@ -31,14 +31,22 @@ public class ServiceExceptionAssertTest {
         ErrorType actualType = ErrorType.FAILED_PRECONDITION;
 
         Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                .hasCode(actualType.code())
                 .hasType(actualType)
                 .hasArgs(SafeArg.of("a", "b"), UnsafeArg.of("c", "d"));
 
         Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                .hasCode(actualType.code())
                 .hasType(actualType)
                 .hasArgs(UnsafeArg.of("c", "d"), SafeArg.of("a", "b")); // Order doesn't matter
 
         Assertions.assertThat(new ServiceException(actualType)).hasNoArgs();
+
+        assertThatThrownBy(() ->
+                        Assertions.assertThat(new ServiceException(actualType)).hasCode(ErrorType.Code.INTERNAL))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining(
+                        "Expected ErrorType.Code to be %s, but found %s", ErrorType.Code.INTERNAL, actualType.code());
 
         assertThatThrownBy(() ->
                         Assertions.assertThat(new ServiceException(actualType)).hasType(ErrorType.INTERNAL))


### PR DESCRIPTION
We have an internal library with methods that throw `ServiceException` with `ErrorType.PERMISSION_DENIED`. However , in order us flexibility to evolve this API, we don't guarantee that these methods will always use `ErrorType.PERMISSION_DENIED`, only that the error code will be `ErrorType.Code.PERMISSION_DENIED`. It would be nice if consumers of this library could make assertions about just the `ErrorType.Code` of a `ServiceException`.

Ultimately we may want something similar for `RemoteExceptionAssert`, but I don't have a concrete use case so it's unclear what the API should be given that `RemoteException` has both an `errorCode` and `status`.