### PR TITLE
Add RemoteException.hasStatus

### DIFF
--- a/changelog/@unreleased/pr-1144.v2.yml
+++ b/changelog/@unreleased/pr-1144.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add `RemoteException.hasStatus` to assert the status of a `RemoteException`.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1144

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/RemoteExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/RemoteExceptionAssert.java
@@ -36,16 +36,20 @@ public class RemoteExceptionAssert extends AbstractThrowableAssert<RemoteExcepti
         return INSTANCE_OF_ASSERT_FACTORY;
     }
 
+    public final RemoteExceptionAssert hasStatus(int status) {
+        isNotNull();
+
+        failIfNotEqual("error status", status, actual.getStatus());
+
+        return this;
+    }
+
     public final RemoteExceptionAssert isGeneratedFromErrorType(ErrorType type) {
         isNotNull();
 
-        String actualCode = actual.getError().errorCode();
-        String actualName = actual.getError().errorName();
-        int actualStatus = actual.getStatus();
-
-        failIfNotEqual("error code", type.code().name(), actualCode);
-        failIfNotEqual("error name", type.name(), actualName);
-        failIfNotEqual("error status", type.httpErrorCode(), actualStatus);
+        failIfNotEqual("error code", type.code().name(), actual.getError().errorCode());
+        failIfNotEqual("error name", type.name(), actual.getError().errorName());
+        failIfNotEqual("error status", type.httpErrorCode(), actual.getStatus());
 
         return this;
     }

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/RemoteExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/RemoteExceptionAssertTest.java
@@ -32,6 +32,7 @@ public final class RemoteExceptionAssertTest {
         SerializableError error = SerializableError.forException(new ServiceException(actualType));
 
         Assertions.assertThat(new RemoteException(error, actualType.httpErrorCode()))
+                .hasStatus(actualType.httpErrorCode())
                 .isGeneratedFromErrorType(actualType);
 
         assertThatThrownBy(() -> Assertions.assertThat(new RemoteException(error, actualType.httpErrorCode() + 1))


### PR DESCRIPTION
Similar to https://github.com/palantir/conjure-java-runtime-api/pull/1103, but for `RemoteException`.