### PR TITLE
Add ServicesConfigBlock singleton

### DIFF
--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServicesConfigBlock.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServicesConfigBlock.java
@@ -35,7 +35,7 @@ import org.immutables.value.Value.Immutable;
  * fully-specified {@link ServiceConfiguration} objects.
  */
 @DoNotLog
-@Immutable
+@Immutable(singleton = true)
 @JsonSerialize(as = ImmutableServicesConfigBlock.class)
 @JsonDeserialize(builder = ServicesConfigBlock.Builder.class)
 @ImmutablesStyle
@@ -104,6 +104,10 @@ public abstract class ServicesConfigBlock {
     @JsonProperty("fallbackToCommonNameVerification")
     @JsonAlias("fallback-to-common-name-verification")
     public abstract Optional<Boolean> defaultFallbackToCommonNameVerification();
+
+    public static ServicesConfigBlock empty() {
+        return ImmutableServicesConfigBlock.of();
+    }
 
     public static Builder builder() {
         return new Builder();


### PR DESCRIPTION
Our internal configuration uses a `Optional<ServicesConfigBlock>` which results in a lot of places where we want to construct an empty `ServicesConfigBlock` and lot of duplicate empty singletons. It would be nice if this was provided by the library.

I think it's unlikely that we will ever add required fields here as doing so would be rather disruptive.