### PR TITLE
Add support for HTTPS proxies

### DIFF
--- a/changelog/@unreleased/pr-1166.v2.yml
+++ b/changelog/@unreleased/pr-1166.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add support for HTTPS proxies
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1166

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -24,11 +24,10 @@ import com.palantir.logsafe.DoNotLog;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-
-import java.util.Optional;
-
 import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
+
+import java.util.Optional;
 
 @DoNotLog
 @Immutable
@@ -42,9 +41,7 @@ public abstract class ProxyConfiguration {
 
     public enum Type {
 
-        /**
-         * Use a direct connection. This option will bypass any JVM-level configured proxy settings.
-         */
+        /** Use a direct connection. This option will bypass any JVM-level configured proxy settings. */
         DIRECT,
 
         /**
@@ -72,9 +69,7 @@ public abstract class ProxyConfiguration {
          */
         MESH,
 
-        /**
-         * Connections are created using a SOCKS proxy.
-         */
+        /** Connections are created using a SOCKS proxy. */
         SOCKS,
     }
 
@@ -86,9 +81,7 @@ public abstract class ProxyConfiguration {
     @JsonAlias("host-and-port")
     public abstract Optional<String> hostAndPort();
 
-    /**
-     * Credentials if the proxy needs authentication.
-     */
+    /** Credentials if the proxy needs authentication. */
     public abstract Optional<BasicCredentials> credentials();
 
     /**
@@ -162,6 +155,5 @@ public abstract class ProxyConfiguration {
         return new Builder();
     }
 
-    public static final class Builder extends ImmutableProxyConfiguration.Builder {
-    }
+    public static final class Builder extends ImmutableProxyConfiguration.Builder {}
 }

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -24,7 +24,9 @@ import com.palantir.logsafe.DoNotLog;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
 import java.util.Optional;
+
 import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
@@ -40,7 +42,9 @@ public abstract class ProxyConfiguration {
 
     public enum Type {
 
-        /** Use a direct connection. This option will bypass any JVM-level configured proxy settings. */
+        /**
+         * Use a direct connection. This option will bypass any JVM-level configured proxy settings.
+         */
         DIRECT,
 
         /**
@@ -55,12 +59,22 @@ public abstract class ProxyConfiguration {
         HTTP,
 
         /**
+         * Use an https-proxy specified by {@link ProxyConfiguration#hostAndPort()} and (optionally)
+         * {@link ProxyConfiguration#credentials()}.
+         * <p>
+         * This is a beta feature and may not be supported by all clients.
+         */
+        HTTPS,
+
+        /**
          * Redirects requests to the {@link #hostAndPort} and sets the HTTP Host header to the original request's
          * authority.
          */
         MESH,
 
-        /** Connections are created using a SOCKS proxy. */
+        /**
+         * Connections are created using a SOCKS proxy.
+         */
         SOCKS,
     }
 
@@ -72,7 +86,9 @@ public abstract class ProxyConfiguration {
     @JsonAlias("host-and-port")
     public abstract Optional<String> hostAndPort();
 
-    /** Credentials if the proxy needs authentication. */
+    /**
+     * Credentials if the proxy needs authentication.
+     */
     public abstract Optional<BasicCredentials> credentials();
 
     /**
@@ -146,5 +162,6 @@ public abstract class ProxyConfiguration {
         return new Builder();
     }
 
-    public static final class Builder extends ImmutableProxyConfiguration.Builder {}
+    public static final class Builder extends ImmutableProxyConfiguration.Builder {
+    }
 }

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -101,6 +101,7 @@ public abstract class ProxyConfiguration {
         switch (type()) {
             case MESH:
             case HTTP:
+            case HTTPS:
                 Preconditions.checkArgument(
                         hostAndPort().isPresent(), "host-and-port must be configured for an HTTP proxy");
                 HostAndPort host = HostAndPort.fromString(hostAndPort().get());

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -24,10 +24,9 @@ import com.palantir.logsafe.DoNotLog;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.Optional;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
-
-import java.util.Optional;
 
 @DoNotLog
 @Immutable
@@ -132,7 +131,8 @@ public abstract class ProxyConfiguration {
         }
 
         if (credentials().isPresent()) {
-            Preconditions.checkArgument(type() == Type.HTTP, "credentials only valid for HTTP proxies");
+            Preconditions.checkArgument(
+                    type() == Type.HTTP || type() == Type.HTTPS, "credentials only valid for HTTP or HTTPS proxies");
         }
     }
 

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -132,7 +132,8 @@ public abstract class ProxyConfiguration {
 
         if (credentials().isPresent()) {
             Preconditions.checkArgument(
-                    type() == Type.HTTP || type() == Type.HTTPS, "credentials only valid for HTTP or HTTPS proxies");
+                    type() == Type.HTTP || type() == Type.HTTPS,
+                    "credentials are only valid for HTTP or HTTPS proxies");
         }
     }
 

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
@@ -122,7 +122,7 @@ public final class ProxyConfigurationTests {
                         .hostAndPort("localhost:1234")
                         .build())
                 .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasLogMessage("credentials only valid for HTTP proxies")
+                .hasLogMessage("credentials only valid for HTTP(S) proxies")
                 .hasNoArgs();
     }
 
@@ -134,7 +134,7 @@ public final class ProxyConfigurationTests {
                         .hostAndPort("localhost:1234")
                         .build())
                 .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasLogMessage("credentials only valid for HTTP proxies")
+                .hasLogMessage("credentials only valid for HTTP(S) proxies")
                 .hasNoArgs();
     }
 

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/ProxyConfigurationTests.java
@@ -122,7 +122,7 @@ public final class ProxyConfigurationTests {
                         .hostAndPort("localhost:1234")
                         .build())
                 .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasLogMessage("credentials only valid for HTTP(S) proxies")
+                .hasLogMessage("credentials are only valid for HTTP or HTTPS proxies")
                 .hasNoArgs();
     }
 
@@ -134,7 +134,7 @@ public final class ProxyConfigurationTests {
                         .hostAndPort("localhost:1234")
                         .build())
                 .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasLogMessage("credentials only valid for HTTP(S) proxies")
+                .hasLogMessage("credentials are only valid for HTTP or HTTPS proxies")
                 .hasNoArgs();
     }
 


### PR DESCRIPTION
Relates to https://github.com/palantir/dialogue/issues/2278
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The ProxyConfiguration API does not allow specifying an HTTPS proxy, a setup where the connection to the proxy is secured with HTTPS.
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==
The ProxyConfiguration API supports specifying HTTPS proxies. This requires changes in https://github.com/palantir/dialogue to honor this setting.
## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

