### PR TITLE
[WIP] Implement additional QoS metadata

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
@@ -110,6 +110,8 @@ public final class QosReason {
 
         private Builder() {}
 
+        // other.reason must be a compile-time-constant
+        @SuppressWarnings("CompileTimeConstant")
         public Builder from(QosReason other) {
             return reason(other.reason()).retryHint(other.retryHint()).dueTo(other.dueTo());
         }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReason.java
@@ -18,9 +18,13 @@ package com.palantir.conjure.java.api.errors;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Objects;
-import java.util.regex.Pattern;
+import java.util.Optional;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 
 /**
  * A class representing the reason why a {@link QosException} was created.
@@ -30,28 +34,43 @@ import java.util.regex.Pattern;
  * tag, for observability into {@link QosException} calls. As such, the string is constrained to have at most 50
  * lowercase alphanumeric characters, and hyphens (-).
  */
+@Safe
 public final class QosReason {
 
-    @CompileTimeConstant
+    @Safe
     private final String reason;
 
-    private static final String PATTERN_STRING = "^[a-z0-9\\-]{1,50}$";
-    private static final Pattern PATTERN = Pattern.compile(PATTERN_STRING);
+    private final Optional<RetryHint> retryHint;
+    private final Optional<DueTo> dueTo;
 
-    private QosReason(@CompileTimeConstant String reason) {
+    private static final String PATTERN_STRING = "^[a-z0-9\\-]{1,50}$";
+
+    private QosReason(@Safe String reason, Optional<RetryHint> retryHint, Optional<DueTo> dueTo) {
+        checkReason(reason);
         this.reason = reason;
+        this.retryHint = retryHint;
+        this.dueTo = dueTo;
     }
 
     public static QosReason of(
-            @CompileTimeConstant @org.intellij.lang.annotations.Pattern(PATTERN_STRING) String reason) {
-        Preconditions.checkArgument(
-                PATTERN.matcher(reason).matches(),
-                "Reason must be at most 50 characters, and only contain lowercase letters, numbers, "
-                        + "and hyphens (-).",
-                SafeArg.of("reason", reason));
-        return new QosReason(reason);
+            @Safe @CompileTimeConstant @org.intellij.lang.annotations.Pattern(PATTERN_STRING) String reason) {
+        return new QosReason(reason, Optional.empty(), Optional.empty());
     }
 
+    @Safe
+    public String reason() {
+        return reason;
+    }
+
+    public Optional<RetryHint> retryHint() {
+        return retryHint;
+    }
+
+    public Optional<DueTo> dueTo() {
+        return dueTo;
+    }
+
+    /** Returns the {@link #reason()} for historical reasons, and should not be updated. */
     @Override
     public String toString() {
         return reason;
@@ -61,16 +80,121 @@ public final class QosReason {
     public boolean equals(Object other) {
         if (other == this) {
             return true;
-        } else if (!(other instanceof QosReason)) {
-            return false;
+        } else if (other instanceof QosReason otherReason) {
+            return Objects.equals(this.reason, otherReason.reason)
+                    && Objects.equals(this.retryHint, otherReason.retryHint)
+                    && Objects.equals(this.dueTo, otherReason.dueTo);
         } else {
-            QosReason otherReason = (QosReason) other;
-            return Objects.equals(this.reason, otherReason.reason);
+            return false;
         }
     }
 
     @Override
     public int hashCode() {
         return Objects.hashCode(this.reason);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        @Nullable
+        private String reason;
+
+        @Nullable
+        private RetryHint retryHint;
+
+        @Nullable
+        private DueTo dueTo;
+
+        private Builder() {}
+
+        public Builder from(QosReason other) {
+            return reason(other.reason()).retryHint(other.retryHint()).dueTo(other.dueTo());
+        }
+
+        public Builder reason(
+                @Safe @CompileTimeConstant @org.intellij.lang.annotations.Pattern(PATTERN_STRING) String value) {
+            this.reason = Preconditions.checkNotNull(value, "reason");
+            return this;
+        }
+
+        public Builder retryHint(RetryHint value) {
+            this.retryHint = Preconditions.checkNotNull(value, "retryHint");
+            return this;
+        }
+
+        public Builder retryHint(Optional<RetryHint> value) {
+            this.retryHint = Preconditions.checkNotNull(value, "retryHint").orElse(null);
+            return this;
+        }
+
+        public Builder dueTo(DueTo value) {
+            this.dueTo = Preconditions.checkNotNull(value, "dueTo");
+            return this;
+        }
+
+        public Builder dueTo(Optional<DueTo> value) {
+            this.dueTo = Preconditions.checkNotNull(value, "dueTo").orElse(null);
+            return this;
+        }
+
+        public QosReason build() {
+            return new QosReason(
+                    Preconditions.checkNotNull(reason, "reason"),
+                    Optional.ofNullable(retryHint),
+                    Optional.ofNullable(dueTo));
+        }
+    }
+
+    public enum RetryHint {
+        // TODO(ckozak): Should we declare the existing default value? Perhaps best if we only
+        // declare the minimal api to opt into new behavior.
+        //        /** Clients should attempt to retry this failure. */
+        //        EAGER,
+        /**
+         * Clients should not attempt to retry this failure,
+         * providing the failure as context back to the initial caller.
+         */
+        PROPAGATE;
+    }
+
+    public enum DueTo {
+        // TODO(ckozak): should we declare values that align with the default 503 and 429 behavior, which
+        // impact rate limiters for the node and endpoint specifically? If we do, they will be propagated
+        // in ways that don't make sense (despite being the default behavior today). Declaring a user limit
+        // may be more reasonable since the user token is generally passed along, however per-endpoint limits
+        // lose some meaning when rethrown by a calling service.
+
+        /**
+         * A cause that the RPC system isn't directly aware of, for example a user or user-agent specific limit, or
+         * based on a specific resource that's being accessed, as opposed to the target node as a whole, or endpoint.
+         * QosReasons with this cause shouldn't impact things like the dialogue concurrency limiter.
+         */
+        CUSTOM;
+    }
+
+    private static void checkReason(@Safe String reason) {
+        if (reason == null || reason.isEmpty() || reason.length() > 50) {
+            throw invalidReason(reason);
+        }
+        for (int i = 0; i < reason.length(); i++) {
+            char character = reason.charAt(i);
+            boolean validCharacter = (character >= 'a' && character <= 'z')
+                    || (character >= '0' && character <= '9')
+                    || character == '-';
+            if (!validCharacter) {
+                throw invalidReason(reason);
+            }
+        }
+    }
+
+    @CheckReturnValue
+    private static SafeIllegalArgumentException invalidReason(@Safe String reason) {
+        return new SafeIllegalArgumentException(
+                "Reason must be at most 50 characters, and only contain lowercase letters, numbers, "
+                        + "and hyphens (-).",
+                SafeArg.of("reason", reason));
     }
 }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReasons.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReasons.java
@@ -22,21 +22,27 @@ import java.util.Optional;
 
 public final class QosReasons {
 
+    private static final String CLIENT_REASON = "client-qos-response";
+    private static final QosReason DEFAULT_CLIENT_REASON = QosReason.of(CLIENT_REASON);
     private static final String DUE_TO_HEADER = "Qos-Due-To";
     private static final String RETRY_HINT_HEADER = "Qos-Retry-Hint";
 
-    public <T> void writeToResponse(QosReason reason, T response, QosResponseEncodingAdapter<? super T> adapter) {
+    public static <T> void encodeToResponse(
+            QosReason reason, T response, QosResponseEncodingAdapter<? super T> adapter) {
         reason.dueTo().ifPresent(dueTo -> adapter.setHeader(response, DUE_TO_HEADER, dueTo.name()));
         reason.retryHint().ifPresent(retryHint -> adapter.setHeader(response, RETRY_HINT_HEADER, retryHint.name()));
     }
 
-    public <T> QosReason parseFromResponse(
-            QosReason defaultReason, T response, QosResponseDecodingAdapter<? super T> adapter) {
+    public static <T> QosReason parseFromResponse(T response, QosResponseDecodingAdapter<? super T> adapter) {
+        Optional<String> maybeDueTo = adapter.getFirstHeader(response, DUE_TO_HEADER);
+        Optional<String> maybeRetryHint = adapter.getFirstHeader(response, RETRY_HINT_HEADER);
+        if (maybeDueTo.isEmpty() && maybeRetryHint.isEmpty()) {
+            return DEFAULT_CLIENT_REASON;
+        }
         return QosReason.builder()
-                .from(defaultReason)
-                .dueTo(adapter.getFirstHeader(response, DUE_TO_HEADER).flatMap(value -> parse(DueTo.class, value)))
-                .retryHint(adapter.getFirstHeader(response, RETRY_HINT_HEADER)
-                        .flatMap(value -> parse(RetryHint.class, value)))
+                .reason(CLIENT_REASON)
+                .dueTo(maybeDueTo.flatMap(value -> parse(DueTo.class, value)))
+                .retryHint(maybeRetryHint.flatMap(value -> parse(RetryHint.class, value)))
                 .build();
     }
 
@@ -48,7 +54,7 @@ public final class QosReasons {
         Optional<String> getFirstHeader(RESPONSE response, String headerName);
     }
 
-    private <T extends Enum<T>> Optional<T> parse(Class<T> type, String value) {
+    private static <T extends Enum<T>> Optional<T> parse(Class<T> type, String value) {
         try {
             return Optional.of(Enum.valueOf(type, value));
         } catch (IllegalArgumentException ignored) {

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReasons.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosReasons.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.conjure.java.api.errors.QosReason.DueTo;
+import com.palantir.conjure.java.api.errors.QosReason.RetryHint;
+import java.util.Optional;
+
+public final class QosReasons {
+
+    private static final String DUE_TO_HEADER = "Qos-Due-To";
+    private static final String RETRY_HINT_HEADER = "Qos-Retry-Hint";
+
+    public <T> void writeToResponse(QosReason reason, T response, QosResponseEncodingAdapter<? super T> adapter) {
+        reason.dueTo().ifPresent(dueTo -> adapter.setHeader(response, DUE_TO_HEADER, dueTo.name()));
+        reason.retryHint().ifPresent(retryHint -> adapter.setHeader(response, RETRY_HINT_HEADER, retryHint.name()));
+    }
+
+    public <T> QosReason parseFromResponse(
+            QosReason defaultReason, T response, QosResponseDecodingAdapter<? super T> adapter) {
+        return QosReason.builder()
+                .from(defaultReason)
+                .dueTo(adapter.getFirstHeader(response, DUE_TO_HEADER).flatMap(value -> parse(DueTo.class, value)))
+                .retryHint(adapter.getFirstHeader(response, RETRY_HINT_HEADER)
+                        .flatMap(value -> parse(RetryHint.class, value)))
+                .build();
+    }
+
+    public interface QosResponseEncodingAdapter<RESPONSE> {
+        void setHeader(RESPONSE response, String headerName, String headerValue);
+    }
+
+    public interface QosResponseDecodingAdapter<RESPONSE> {
+        Optional<String> getFirstHeader(RESPONSE response, String headerName);
+    }
+
+    private <T extends Enum<T>> Optional<T> parse(Class<T> type, String value) {
+        try {
+            return Optional.of(Enum.valueOf(type, value));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private QosReasons() {}
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java
@@ -72,7 +72,9 @@ public final class QosExceptionTest {
                 "reason-reason-reason-reason-reason-reason-reason---",
                 // Unsupported characters
                 "reason?",
-                "Reason"
+                "Reason",
+                // too short
+                ""
             })
     public void testInvalidReason(@CompileTimeConstant String reason) {
         assertThatLoggableExceptionThrownBy(() -> QosReason.of(reason))

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/QosReasonsTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/QosReasonsTest.java
@@ -1,0 +1,86 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.conjure.java.api.errors.QosReason.DueTo;
+import com.palantir.conjure.java.api.errors.QosReason.RetryHint;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class QosReasonsTest {
+
+    @Test
+    public void testReasonWithNoAdditionalFields() {
+        Map<String, String> headers = new HashMap<>();
+        QosReason reason = QosReason.of("reason");
+        QosReasons.encodeToResponse(reason, headers, Encoder.INSTANCE);
+        assertThat(headers).isEmpty();
+    }
+
+    @Test
+    public void testReasonWithFields() {
+        Map<String, String> headers = new HashMap<>();
+        QosReason reason = QosReason.builder()
+                .reason("reason")
+                .dueTo(DueTo.CUSTOM)
+                .retryHint(RetryHint.PROPAGATE)
+                .build();
+        QosReasons.encodeToResponse(reason, headers, Encoder.INSTANCE);
+        assertThat(headers).isEqualTo(ImmutableMap.of("Qos-Due-To", "CUSTOM", "Qos-Retry-Hint", "PROPAGATE"));
+    }
+
+    @Test
+    public void testRoundTrip() {
+        Map<String, String> headers = new HashMap<>();
+        QosReason original = QosReason.builder()
+                .reason("reason")
+                .dueTo(DueTo.CUSTOM)
+                .retryHint(RetryHint.PROPAGATE)
+                .build();
+        QosReasons.encodeToResponse(original, headers, Encoder.INSTANCE);
+        QosReason recreated = QosReasons.parseFromResponse(headers, Decoder.INSTANCE);
+        assertThat(recreated).isNotEqualTo(original);
+        assertThat(recreated)
+                .isEqualTo(QosReason.builder()
+                        .from(original)
+                        .reason("client-qos-response")
+                        .build());
+    }
+
+    private enum Encoder implements QosReasons.QosResponseEncodingAdapter<Map<String, String>> {
+        INSTANCE;
+
+        @Override
+        public void setHeader(Map<String, String> stringStringMap, String headerName, String headerValue) {
+            stringStringMap.put(headerName, headerValue);
+        }
+    }
+
+    private enum Decoder implements QosReasons.QosResponseDecodingAdapter<Map<String, String>> {
+        INSTANCE;
+
+        @Override
+        public Optional<String> getFirstHeader(Map<String, String> stringStringMap, String headerName) {
+            return Optional.ofNullable(stringStringMap.get(headerName));
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
No way to provide additional context with QoS exceptions.

## After this PR
==COMMIT_MSG==
Implement additional QoS metadata
==COMMIT_MSG==

This PR provides two pieces:
1. QosReason provides additional fields: `RetryHint` and `DueTo`
2. We provide a `QosReasons` utility which handles recording this metadata to a response, and recording from a response. This allows us to make changes/additions over time without updating projects that use these utilities.

## Possible downsides?
This adds complexity to our QoS exceptions, which are already somewhat complicated to reason about. We need additional control over how QoS responses impact the system as a whole, so this should be a reasonable trade-off.
