### PR TITLE
Include dueTo and retryHint in QosException SafeLoggable.getArgs

### DIFF
--- a/changelog/@unreleased/pr-1248.v2.yml
+++ b/changelog/@unreleased/pr-1248.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Include dueTo and retryHint in QosException SafeLoggable args
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1248

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/QosException.java
@@ -24,7 +24,6 @@ import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.UnsafeArg;
 import java.net.URL;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -224,7 +223,11 @@ public abstract class QosException extends RuntimeException {
 
         @Override
         public List<Arg<?>> getArgs() {
-            return List.of(SafeArg.of("retryAfter", retryAfter.orElse(null)), SafeArg.of("reason", getReason()));
+            return List.of(
+                    SafeArg.of("retryAfter", retryAfter.orElse(null)),
+                    SafeArg.of("reason", getReason().reason()),
+                    SafeArg.of("dueTo", getReason().dueTo().orElse(null)),
+                    SafeArg.of("retryHint", getReason().retryHint().orElse(null)));
         }
     }
 
@@ -272,7 +275,11 @@ public abstract class QosException extends RuntimeException {
         @Unsafe
         @Override
         public List<Arg<?>> getArgs() {
-            return List.of(UnsafeArg.of("redirectTo", redirectTo), SafeArg.of("reason", getReason()));
+            return List.of(
+                    UnsafeArg.of("redirectTo", redirectTo),
+                    SafeArg.of("reason", getReason().reason()),
+                    SafeArg.of("dueTo", getReason().dueTo().orElse(null)),
+                    SafeArg.of("retryHint", getReason().retryHint().orElse(null)));
         }
     }
 
@@ -310,7 +317,10 @@ public abstract class QosException extends RuntimeException {
 
         @Override
         public List<Arg<?>> getArgs() {
-            return Collections.singletonList(SafeArg.of("reason", getReason()));
+            return List.of(
+                    SafeArg.of("reason", getReason().reason()),
+                    SafeArg.of("dueTo", getReason().dueTo().orElse(null)),
+                    SafeArg.of("retryHint", getReason().retryHint().orElse(null)));
         }
     }
 }

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/QosExceptionTest.java
@@ -20,6 +20,8 @@ import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptio
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.conjure.java.api.errors.QosReason.DueTo;
+import com.palantir.conjure.java.api.errors.QosReason.RetryHint;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.net.MalformedURLException;
@@ -57,12 +59,19 @@ public final class QosExceptionTest {
 
     @Test
     public void testReason() {
-        QosReason reason = QosReason.of("custom-reason");
+        QosReason reason = QosReason.builder()
+                .reason("custom-reason")
+                .dueTo(DueTo.CUSTOM)
+                .retryHint(RetryHint.DO_NOT_RETRY)
+                .build();
         assertThat(QosException.throttle(reason).getReason()).isEqualTo(reason);
         assertThatLoggableExceptionThrownBy(() -> {
                     throw QosException.throttle(reason);
                 })
-                .containsArgs(SafeArg.of("reason", reason));
+                .containsArgs(
+                        SafeArg.of("reason", "custom-reason"),
+                        SafeArg.of("retryHint", RetryHint.DO_NOT_RETRY),
+                        SafeArg.of("dueTo", DueTo.CUSTOM));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Quality of life observability improvement that I missed on the initial implementation

==COMMIT_MSG==
Include dueTo and retryHint in QosException SafeLoggable args
==COMMIT_MSG==
