### PR TITLE
Add checked service exception, used for endpoint associated errors

### DIFF
--- a/changelog/@unreleased/pr-1262.v2.yml
+++ b/changelog/@unreleased/pr-1262.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add a checked service exception, used for endpoint associated errors
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1262

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,32 +21,29 @@ import com.palantir.logsafe.SafeLoggable;
 import java.util.List;
 import javax.annotation.Nullable;
 
-/** A {@link ServiceException} thrown in server-side code to indicate server-side {@link ErrorType error states}. */
-public final class ServiceException extends RuntimeException implements SafeLoggable {
-    private static final String EXCEPTION_NAME = "ServiceException";
+/**
+ * An exception raised by a service to indicate an expected error state.
+ */
+public abstract class CheckedServiceException extends Exception implements SafeLoggable {
+    private static final String EXCEPTION_NAME = "CheckedServiceException";
     private final ErrorType errorType;
-    private final List<Arg<?>> args; // unmodifiable
-
+    private final List<Arg<?>> args; // This is an unmodifiable list.
     private final String errorInstanceId;
     private final String unsafeMessage;
     private final String noArgsMessage;
 
     /**
-     * Creates a new exception for the given error. All {@link com.palantir.logsafe.Arg parameters} are propagated to
-     * clients; they are serialized via {@link Object#toString}.
+     * Creates a new exception for the given error.
      */
-    public ServiceException(ErrorType errorType, Arg<?>... parameters) {
+    public CheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
         this(errorType, null, parameters);
     }
 
     /** As above, but additionally records the cause of this exception. */
-    public ServiceException(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
-        // TODO(rfink): Memoize formatting?
+    public CheckedServiceException(ErrorType errorType, @Nullable Throwable cause, Arg<?>... args) {
         super(cause);
-
         this.errorInstanceId = ServiceExceptionUtils.generateErrorInstanceId(cause);
         this.errorType = errorType;
-        // Note that instantiators cannot mutate List<> args since it comes through copyToList in all code paths.
         this.args = ServiceExceptionUtils.arrayToUnmodifiableList(args);
         this.unsafeMessage = ServiceExceptionUtils.renderUnsafeMessage(EXCEPTION_NAME, errorType, args);
         this.noArgsMessage = ServiceExceptionUtils.renderNoArgsMessage(EXCEPTION_NAME, errorType);
@@ -62,30 +59,22 @@ public final class ServiceException extends RuntimeException implements SafeLogg
         return errorInstanceId;
     }
 
+    /** A string that includes the exception name, error type, and all arguments irrespective of log-safety. */
     @Override
     public String getMessage() {
         // Including all args here since any logger not configured with safe-logging will log this message.
         return unsafeMessage;
     }
 
+    /** A string that includes the exception name and error type, without any arguments. */
     @Override
     public String getLogMessage() {
-        // Not returning safe args here since the safe-logging framework will log this message + args explicitly.
         return noArgsMessage;
     }
 
+    /** The list of arguments. */
     @Override
     public List<Arg<?>> getArgs() {
         return args;
-    }
-
-    /**
-     * Deprecated.
-     *
-     * @deprecated use {@link #getArgs}.
-     */
-    @Deprecated
-    public List<Arg<?>> getParameters() {
-        return getArgs();
     }
 }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
@@ -33,7 +33,8 @@ public abstract class CheckedServiceException extends Exception implements SafeL
     private final String noArgsMessage;
 
     /**
-     * Creates a new exception for the given error.
+     * Creates a new exception for the given error. All {@link com.palantir.logsafe.Arg parameters} are propagated to
+     * clients.
      */
     public CheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
         this(errorType, null, parameters);

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/CheckedServiceException.java
@@ -51,31 +51,31 @@ public abstract class CheckedServiceException extends Exception implements SafeL
     }
 
     /** The {@link ErrorType} that gave rise to this exception. */
-    public ErrorType getErrorType() {
+    public final ErrorType getErrorType() {
         return errorType;
     }
 
     /** A unique identifier for (this instance of) this error. */
-    public String getErrorInstanceId() {
+    public final String getErrorInstanceId() {
         return errorInstanceId;
     }
 
     /** A string that includes the exception name, error type, and all arguments irrespective of log-safety. */
     @Override
-    public String getMessage() {
+    public final String getMessage() {
         // Including all args here since any logger not configured with safe-logging will log this message.
         return unsafeMessage;
     }
 
     /** A string that includes the exception name and error type, without any arguments. */
     @Override
-    public String getLogMessage() {
+    public final String getLogMessage() {
         return noArgsMessage;
     }
 
     /** The list of arguments. */
     @Override
-    public List<Arg<?>> getArgs() {
+    public final List<Arg<?>> getArgs() {
         return args;
     }
 }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceExceptionUtils.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceExceptionUtils.java
@@ -1,0 +1,130 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.logsafe.Arg;
+import com.palantir.tritium.ids.UniqueIds;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * This class is a collection of methods useful for creating {@link ServiceException}s and {@link CheckedServiceException}s.
+ */
+final class ServiceExceptionUtils {
+    private ServiceExceptionUtils() {}
+
+    /**
+     * Creates an unmodifiable list from the given array. Null entries are filtered out as unmodifiable lists cannot
+     * have null elements.
+     *
+     * @param elements the array to convert to an unmodifiable list
+     * @return an unmodifiable list containing the non-null elements of the array
+     * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Collection.html#unmodview">unmodifiable view</a>
+     */
+    static <T> List<T> arrayToUnmodifiableList(T[] elements) {
+        if (elements == null || elements.length == 0) {
+            return Collections.emptyList();
+        }
+        List<T> list = new ArrayList<>(elements.length);
+        for (T item : elements) {
+            if (item != null) {
+                list.add(item);
+            }
+        }
+        return Collections.unmodifiableList(list);
+    }
+
+    /**
+     * Create a message string that includes the exception name, error type, and all arguments irrespective of log
+     * safety.
+     *
+     * @param exceptionName the name of the exception for which the message is being rendered
+     * @param errorType the error type the exception represents
+     * @param args the arguments to be included in the message
+     * @return a message string that includes the exception name, error type, and arguments
+     */
+    static String renderUnsafeMessage(String exceptionName, ErrorType errorType, Arg<?>... args) {
+        String message = renderNoArgsMessage(exceptionName, errorType);
+
+        if (args == null || args.length == 0) {
+            return message;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(message).append(": {");
+        boolean first = true;
+        for (Arg<?> arg : args) {
+            if (arg == null) {
+                continue;
+            }
+            if (first) {
+                first = false;
+            } else {
+                builder.append(", ");
+            }
+            builder.append(arg.getName()).append("=").append(arg.getValue());
+        }
+        builder.append("}");
+
+        return builder.toString();
+    }
+
+    /**
+     * Create a message string that includes the exception name and error type, but no arguments.
+     *
+     * @param exceptionName the name of the exception for which the message is being rendered
+     * @param errorType the error type the exception represents
+     * @return a message string
+     */
+    static String renderNoArgsMessage(String exceptionName, ErrorType errorType) {
+        return exceptionName + ": " + errorType.code() + " (" + errorType.name() + ")";
+    }
+
+    /**
+     * Finds the errorInstanceId of the most recent cause if present, otherwise generates a new random identifier. Note
+     * that this only searches {@link Throwable#getCause() causal exceptions}, not {@link Throwable#getSuppressed()
+     * suppressed causes}.
+     */
+    // VisibleForTesting
+    static String generateErrorInstanceId(@Nullable Throwable cause) {
+        return generateErrorInstanceId(cause, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static String generateErrorInstanceId(
+            @Nullable Throwable cause,
+            // Guard against cause cycles, see Throwable.printStackTrace(PrintStreamOrWriter)
+            Set<Throwable> dejaVu) {
+        if (cause == null || !dejaVu.add(cause)) {
+            // we don't need cryptographically secure random UUIDs
+            return UniqueIds.pseudoRandomUuidV4().toString();
+        }
+        if (cause instanceof ServiceException) {
+            return ((ServiceException) cause).getErrorInstanceId();
+        }
+        if (cause instanceof CheckedServiceException) {
+            return ((CheckedServiceException) cause).getErrorInstanceId();
+        }
+        if (cause instanceof RemoteException) {
+            return ((RemoteException) cause).getError().errorInstanceId();
+        }
+        return generateErrorInstanceId(cause.getCause(), dejaVu);
+    }
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
@@ -30,16 +30,6 @@ public final class CheckedServiceExceptionTest {
     private static final ErrorType ERROR = ErrorType.create(ErrorType.Code.CUSTOM_CLIENT, ERROR_NAME);
     private static final String EXPECTED_ERROR_MSG = "CheckedServiceException: CUSTOM_CLIENT (Namespace:MyDesc)";
 
-    private static class TestCheckedServiceException extends CheckedServiceException {
-        TestCheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
-            super(errorType, parameters);
-        }
-
-        TestCheckedServiceException(ErrorType errorType, Throwable cause, Arg<?>... parameters) {
-            super(errorType, cause, parameters);
-        }
-    }
-
     @Test
     public void testExceptionMessageContainsNoArgs_safeLogMessageContainsSafeArgsOnly() {
         Arg<?>[] args = {SafeArg.of("arg1", "foo"), UnsafeArg.of("arg2", 2), UnsafeArg.of("arg3", null)};
@@ -102,6 +92,14 @@ public final class CheckedServiceExceptionTest {
     @Test
     public void testErrorIdsAreInheritedFromCheckedServiceExceptions() {
         CheckedServiceException rootCause = new TestCheckedServiceException(ERROR);
+        SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
+        CheckedServiceException parent = new TestCheckedServiceException(ERROR, intermediate);
+        assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getErrorInstanceId());
+    }
+
+    @Test
+    public void testErrorIdsAreInheritedFromServiceExceptions() {
+        ServiceException rootCause = new ServiceException(ERROR);
         SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
         CheckedServiceException parent = new TestCheckedServiceException(ERROR, intermediate);
         assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getErrorInstanceId());

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
@@ -1,0 +1,130 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public final class CheckedServiceExceptionTest {
+    private static final String ERROR_NAME = "Namespace:MyDesc";
+    private static final ErrorType ERROR = ErrorType.create(ErrorType.Code.CUSTOM_CLIENT, ERROR_NAME);
+    private static final String EXPECTED_ERROR_MSG = "CheckedServiceException: CUSTOM_CLIENT (Namespace:MyDesc)";
+
+    private static class TestCheckedServiceException extends CheckedServiceException {
+        TestCheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
+            super(errorType, parameters);
+        }
+
+        TestCheckedServiceException(ErrorType errorType, Throwable cause, Arg<?>... parameters) {
+            super(errorType, cause, parameters);
+        }
+    }
+
+    @Test
+    public void testExceptionMessageContainsNoArgs_safeLogMessageContainsSafeArgsOnly() {
+        Arg<?>[] args = {SafeArg.of("arg1", "foo"), UnsafeArg.of("arg2", 2), UnsafeArg.of("arg3", null)};
+        CheckedServiceException ex = new TestCheckedServiceException(ERROR, args);
+
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg2=2, arg3=null}");
+    }
+
+    @Test
+    public void testExceptionMessageWithDuplicateKeys() {
+        CheckedServiceException ex =
+                new TestCheckedServiceException(ERROR, SafeArg.of("arg1", "foo"), SafeArg.of("arg1", 2));
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg1=2}");
+    }
+
+    @Test
+    public void testExceptionMessageWithUnsafeArgs() {
+        CheckedServiceException ex =
+                new TestCheckedServiceException(ERROR, UnsafeArg.of("arg1", 1), SafeArg.of("arg2", 2));
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
+    }
+
+    @Test
+    public void testExceptionMessageWithNullArg() {
+        CheckedServiceException ex =
+                new TestCheckedServiceException(ERROR, UnsafeArg.of("arg1", 1), null, SafeArg.of("arg2", 2));
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
+        assertThat(ex.getArgs()).doesNotContainNull().hasSize(2);
+    }
+
+    @Test
+    public void testExceptionMessageWithNoArgs() {
+        CheckedServiceException ex = new TestCheckedServiceException(ERROR);
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+    }
+
+    @Test
+    public void testExceptionCause() {
+        Throwable cause = new RuntimeException("foo");
+        CheckedServiceException ex = new TestCheckedServiceException(ERROR, cause);
+
+        assertThat(ex.getCause()).isEqualTo(cause);
+    }
+
+    @Test
+    public void testStatus() {
+        CheckedServiceException ex = new TestCheckedServiceException(ERROR);
+        assertThat(ex.getErrorType().httpErrorCode()).isEqualTo(400);
+    }
+
+    @Test
+    public void testErrorIdsAreUnique() {
+        UUID errorId1 = UUID.fromString(new TestCheckedServiceException(ERROR).getErrorInstanceId());
+        UUID errorId2 = UUID.fromString(new TestCheckedServiceException(ERROR).getErrorInstanceId());
+
+        assertThat(errorId1).isNotEqualTo(errorId2);
+    }
+
+    @Test
+    public void testErrorIdsAreInheritedFromCheckedServiceExceptions() {
+        CheckedServiceException rootCause = new TestCheckedServiceException(ERROR);
+        SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
+        CheckedServiceException parent = new TestCheckedServiceException(ERROR, intermediate);
+        assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getErrorInstanceId());
+    }
+
+    @Test
+    public void testErrorIdsAreInheritedFromRemoteExceptions() {
+        RemoteException rootCause = new RemoteException(
+                new SerializableError.Builder()
+                        .errorCode("errorCode")
+                        .errorName("errorName")
+                        .build(),
+                500);
+        SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
+        CheckedServiceException parent = new TestCheckedServiceException(ERROR, intermediate);
+        assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getError().errorInstanceId());
+    }
+
+    @Test
+    public void testCircularCause() {
+        RuntimeException first = new RuntimeException();
+        RuntimeException second = new RuntimeException(first);
+        first.initCause(second);
+        assertThat(ServiceExceptionUtils.generateErrorInstanceId(second)).isNotNull();
+    }
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/CheckedServiceExceptionTest.java
@@ -33,7 +33,7 @@ public final class CheckedServiceExceptionTest {
     @Test
     public void testExceptionMessageContainsNoArgs_safeLogMessageContainsSafeArgsOnly() {
         Arg<?>[] args = {SafeArg.of("arg1", "foo"), UnsafeArg.of("arg2", 2), UnsafeArg.of("arg3", null)};
-        CheckedServiceException ex = new TestCheckedServiceException(ERROR, args);
+        CheckedServiceException ex = new TestError(ERROR, args);
 
         assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg2=2, arg3=null}");
@@ -41,59 +41,56 @@ public final class CheckedServiceExceptionTest {
 
     @Test
     public void testExceptionMessageWithDuplicateKeys() {
-        CheckedServiceException ex =
-                new TestCheckedServiceException(ERROR, SafeArg.of("arg1", "foo"), SafeArg.of("arg1", 2));
+        CheckedServiceException ex = new TestError(ERROR, SafeArg.of("arg1", "foo"), SafeArg.of("arg1", 2));
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo, arg1=2}");
     }
 
     @Test
     public void testExceptionMessageWithUnsafeArgs() {
-        CheckedServiceException ex =
-                new TestCheckedServiceException(ERROR, UnsafeArg.of("arg1", 1), SafeArg.of("arg2", 2));
+        CheckedServiceException ex = new TestError(ERROR, UnsafeArg.of("arg1", 1), SafeArg.of("arg2", 2));
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
     }
 
     @Test
     public void testExceptionMessageWithNullArg() {
-        CheckedServiceException ex =
-                new TestCheckedServiceException(ERROR, UnsafeArg.of("arg1", 1), null, SafeArg.of("arg2", 2));
+        CheckedServiceException ex = new TestError(ERROR, UnsafeArg.of("arg1", 1), null, SafeArg.of("arg2", 2));
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=1, arg2=2}");
         assertThat(ex.getArgs()).doesNotContainNull().hasSize(2);
     }
 
     @Test
     public void testExceptionMessageWithNoArgs() {
-        CheckedServiceException ex = new TestCheckedServiceException(ERROR);
+        CheckedServiceException ex = new TestError(ERROR);
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG);
     }
 
     @Test
     public void testExceptionCause() {
         Throwable cause = new RuntimeException("foo");
-        CheckedServiceException ex = new TestCheckedServiceException(ERROR, cause);
+        CheckedServiceException ex = new TestError(ERROR, cause);
 
         assertThat(ex.getCause()).isEqualTo(cause);
     }
 
     @Test
     public void testStatus() {
-        CheckedServiceException ex = new TestCheckedServiceException(ERROR);
+        CheckedServiceException ex = new TestError(ERROR);
         assertThat(ex.getErrorType().httpErrorCode()).isEqualTo(400);
     }
 
     @Test
     public void testErrorIdsAreUnique() {
-        UUID errorId1 = UUID.fromString(new TestCheckedServiceException(ERROR).getErrorInstanceId());
-        UUID errorId2 = UUID.fromString(new TestCheckedServiceException(ERROR).getErrorInstanceId());
+        UUID errorId1 = UUID.fromString(new TestError(ERROR).getErrorInstanceId());
+        UUID errorId2 = UUID.fromString(new TestError(ERROR).getErrorInstanceId());
 
         assertThat(errorId1).isNotEqualTo(errorId2);
     }
 
     @Test
     public void testErrorIdsAreInheritedFromCheckedServiceExceptions() {
-        CheckedServiceException rootCause = new TestCheckedServiceException(ERROR);
+        CheckedServiceException rootCause = new TestError(ERROR);
         SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
-        CheckedServiceException parent = new TestCheckedServiceException(ERROR, intermediate);
+        CheckedServiceException parent = new TestError(ERROR, intermediate);
         assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getErrorInstanceId());
     }
 
@@ -101,7 +98,7 @@ public final class CheckedServiceExceptionTest {
     public void testErrorIdsAreInheritedFromServiceExceptions() {
         ServiceException rootCause = new ServiceException(ERROR);
         SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
-        CheckedServiceException parent = new TestCheckedServiceException(ERROR, intermediate);
+        CheckedServiceException parent = new TestError(ERROR, intermediate);
         assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getErrorInstanceId());
     }
 
@@ -114,7 +111,7 @@ public final class CheckedServiceExceptionTest {
                         .build(),
                 500);
         SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
-        CheckedServiceException parent = new TestCheckedServiceException(ERROR, intermediate);
+        CheckedServiceException parent = new TestError(ERROR, intermediate);
         assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getError().errorInstanceId());
     }
 

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
@@ -96,6 +96,14 @@ public final class ServiceExceptionTest {
     }
 
     @Test
+    public void testErrorIdsAreInheritedFromCheckedServiceExceptions() {
+        CheckedServiceException rootCause = new TestCheckedServiceException(ERROR);
+        SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
+        ServiceException parent = new ServiceException(ERROR, intermediate);
+        assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getErrorInstanceId());
+    }
+
+    @Test
     public void testErrorIdsAreInheritedFromRemoteExceptions() {
         RemoteException rootCause = new RemoteException(
                 new SerializableError.Builder()

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ServiceExceptionTest.java
@@ -97,7 +97,7 @@ public final class ServiceExceptionTest {
 
     @Test
     public void testErrorIdsAreInheritedFromCheckedServiceExceptions() {
-        CheckedServiceException rootCause = new TestCheckedServiceException(ERROR);
+        CheckedServiceException rootCause = new TestError(ERROR);
         SafeRuntimeException intermediate = new SafeRuntimeException("Handled an exception", rootCause);
         ServiceException parent = new ServiceException(ERROR, intermediate);
         assertThat(parent.getErrorInstanceId()).isEqualTo(rootCause.getErrorInstanceId());

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/TestCheckedServiceException.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/TestCheckedServiceException.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.logsafe.Arg;
+
+final class TestCheckedServiceException extends CheckedServiceException {
+    TestCheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
+        super(errorType, parameters);
+    }
+
+    TestCheckedServiceException(ErrorType errorType, Throwable cause, Arg<?>... parameters) {
+        super(errorType, cause, parameters);
+    }
+}

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/TestError.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/TestError.java
@@ -18,12 +18,12 @@ package com.palantir.conjure.java.api.errors;
 
 import com.palantir.logsafe.Arg;
 
-final class TestCheckedServiceException extends CheckedServiceException {
-    TestCheckedServiceException(ErrorType errorType, Arg<?>... parameters) {
+final class TestError extends CheckedServiceException {
+    TestError(ErrorType errorType, Arg<?>... parameters) {
         super(errorType, parameters);
     }
 
-    TestCheckedServiceException(ErrorType errorType, Throwable cause, Arg<?>... parameters) {
+    TestError(ErrorType errorType, Throwable cause, Arg<?>... parameters) {
         super(errorType, cause, parameters);
     }
 }


### PR DESCRIPTION
## Before this PR
In order to support work to generated checked exceptions for endpoint associated errors, we need to add a `CheckedServiceException`.

Please see [this PR in conjure](https://github.com/palantir/conjure/pull/1670) for high level context, and [this PR in `conjure-java`](https://github.com/palantir/conjure-java/pull/2401) for context on the Java-specific implementation.

## After this PR
==COMMIT_MSG==
Add a checked service exception, used for endpoint associated errors
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

