### PR TITLE
Minor update to doc string 

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -114,7 +114,7 @@ public abstract class SerializableError implements Serializable {
 
     /**
      * Creates a {@link SerializableError} representation of this exception that derives from the error code and
-     * message, as well as the {@link Arg#isSafeForLogging safe} and unsafe {@link ServiceException#args parameters}.
+     * type, as well as the {@link Arg#isSafeForLogging safe} and unsafe {@link ServiceException#args parameters}.
      */
     public static SerializableError forException(ServiceException exception) {
         Builder builder = new Builder()


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Doc referenced the message in ServiceException, however the serviceException.unsafeMessage or unsafeMessage.noArgsMessage is not referenced at all.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Correct doc string
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

