### PR TITLE
faster parsing for primary name component of user-agent strings

### DIFF
--- a/changelog/@unreleased/pr-1272.v2.yml
+++ b/changelog/@unreleased/pr-1272.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: faster parsing for primary name component of user-agent strings
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1272

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -98,11 +98,7 @@ public final class UserAgents {
             return "unknown";
         }
         int split = userAgent.indexOf('/');
-        if (split < 0) {
-            return "unknown";
-        }
-        String primaryName = userAgent.substring(0, split);
-        if (primaryName.isEmpty()) {
+        if (split <= 0) {
             return "unknown";
         }
         // the regex-based logic will only match on blocks of the form "foo/1.2.3 (some extra stuff)", where the name
@@ -110,22 +106,22 @@ public final class UserAgents {
         // it will possibly ignore leading characters (even non-whitespace) up until the "foo/1.2.3" part
         // so we further split primaryName into _just_ the set of characters immediately preceding
         // the "/" for which isValidCharForName() returns true.
-        int lindex = primaryName.length() - 1;
+        int lindex = split - 1;
         while (lindex >= 0) {
-            if (!isValidCharForName(primaryName.charAt(lindex))) {
+            if (!isValidCharForName(userAgent.charAt(lindex))) {
                 break;
             }
             --lindex;
         }
         // lindex points to the first invalid character encountered walking backwards, which we want to exclude
-        primaryName = primaryName.substring(lindex + 1);
+        ++lindex;
         // the first character must match isAlpha()
-        if (!isAlpha(primaryName.charAt(0))) {
+        if (!isAlpha(userAgent.charAt(lindex))) {
             return "unknown";
         }
         // we can avoid an extra call to isValidName() now, since we have validated that the first character matches
         // isAlpha(), and every character thereafter matches isValidCharForName()
-        return primaryName;
+        return userAgent.substring(lindex, split);
     }
 
     private static UserAgent parseInternal(String userAgent, boolean lenient) {

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -119,9 +119,12 @@ public final class UserAgents {
         }
         // lindex points to the first invalid character encountered walking backwards, which we want to exclude
         primaryName = primaryName.substring(lindex + 1);
-        if (!isValidName(primaryName)) {
+        // the first character must match isAlpha()
+        if (!isAlpha(primaryName.charAt(0))) {
             return "unknown";
         }
+        // we can avoid an extra call to isValidName() now, since we have validated that the first character matches
+        // isAlpha(), and every character thereafter matches isValidCharForName()
         return primaryName;
     }
 

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -86,6 +86,45 @@ public final class UserAgents {
         return parseInternal(userAgent == null ? "" : userAgent, true /* lenient */);
     }
 
+    /**
+     * Parse and return only the `name` component of the primary user-agent string, or "unknown" if no valid primary
+     * agent name can be parsed.
+     *
+     * This is functionally similar to calling `tryParse(userAgent).primary().name()`, but optimized to not use
+     * regular expressions.
+     */
+    public static String tryParsePrimaryName(String userAgent) {
+        if (userAgent == null) {
+            return "unknown";
+        }
+        int split = userAgent.indexOf('/');
+        if (split < 0) {
+            return "unknown";
+        }
+        String primaryName = userAgent.substring(0, split);
+        if (primaryName.isEmpty()) {
+            return "unknown";
+        }
+        // the regex-based logic will only match on blocks of the form "foo/1.2.3 (some extra stuff)", where the name
+        // component "foo" must match NAME_REGEX (or return true from isValidName()). this means that
+        // it will possibly ignore leading characters (even non-whitespace) up until the "foo/1.2.3" part
+        // so we further split primaryName into _just_ the set of characters immediately preceding
+        // the "/" for which isValidCharForName() returns true.
+        int lindex = primaryName.length() - 1;
+        while (lindex >= 0) {
+            if (!isValidCharForName(primaryName.charAt(lindex))) {
+                break;
+            }
+            --lindex;
+        }
+        // lindex points to the first invalid character encountered walking backwards, which we want to exclude
+        primaryName = primaryName.substring(lindex + 1);
+        if (!isValidName(primaryName)) {
+            return "unknown";
+        }
+        return primaryName;
+    }
+
     private static UserAgent parseInternal(String userAgent, boolean lenient) {
         ImmutableUserAgent.Builder builder = ImmutableUserAgent.builder();
 
@@ -157,12 +196,16 @@ public final class UserAgents {
 
         for (int i = 1; i < name.length(); i++) {
             ch = name.charAt(i);
-            if (!isAlpha(ch) && !isNumeric(ch) && ch != '-') {
+            if (!isValidCharForName(ch)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static boolean isValidCharForName(char ch) {
+        return isAlpha(ch) || isNumeric(ch) || ch == '-';
     }
 
     private static boolean isAlpha(char ch) {

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -115,6 +115,10 @@ public final class UserAgents {
         }
         // lindex points to the first invalid character encountered walking backwards, which we want to exclude
         ++lindex;
+        if (lindex == split) {
+            // empty substring
+            return "unknown";
+        }
         // the first character must match isAlpha()
         if (!isAlpha(userAgent.charAt(lindex))) {
             return "unknown";

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -218,13 +218,6 @@ public class UserAgentTest {
         validateTryParsePrimaryName(" serviceA/1.2.3", "serviceA");
         validateTryParsePrimaryName("\tserviceA/1.2.3", "serviceA");
         validateTryParsePrimaryName("&/1.2.3", "unknown");
-
-        // tryParsePrimaryName explicitly tries to avoid doing extra work like parsing a version string, which
-        // relies on a regex match that could be expensive (and we're not interested in it anyway)
-        // this means calls can sometimes have unintended behavior for a user-agent string that's not well formed,
-        // but that's probably okay for most use cases
-        // assertThat(UserAgents.tryParsePrimaryName("foo/")).isEqualTo("foo");
-        validateTryParsePrimaryName("foo/", "foo");
     }
 
     @Test

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -220,6 +220,7 @@ public class UserAgentTest {
                 .isEqualTo("serviceA");
         assertThat(UserAgents.tryParsePrimaryName(" serviceA/1.2.3")).isEqualTo("serviceA");
         assertThat(UserAgents.tryParsePrimaryName("\tserviceA/1.2.3")).isEqualTo("serviceA");
+        assertThat(UserAgents.tryParsePrimaryName("&/1.2.3")).isEqualTo("unknown");
 
         // tryParsePrimaryName explicitly tries to avoid doing extra work like parsing a version string, which
         // relies on a regex match that could be expensive (and we're not interested in it anyway)

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -199,34 +199,53 @@ public class UserAgentTest {
 
     @Test
     public void tryParsePrimaryName_ignoresExtraStuff() {
-        assertThat(UserAgents.tryParsePrimaryName("serviceA/1.2.3")).isEqualTo("serviceA");
-        assertThat(UserAgents.tryParsePrimaryName("serviceA/1.2.3 (foobar)")).isEqualTo("serviceA");
-        assertThat(UserAgents.tryParsePrimaryName("serviceA/1.2.3 serviceB/4.5.6 (foobar fizz buzz"))
-                .isEqualTo("serviceA");
+        validateTryParsePrimaryName("serviceA/1.2.3", "serviceA");
+        validateTryParsePrimaryName("serviceA/1.2.3", "serviceA");
+        validateTryParsePrimaryName("serviceA/1.2.3 (foobar)", "serviceA");
+        validateTryParsePrimaryName("serviceA/1.2.3 serviceB/4.5.6 (foobar fizz buzz", "serviceA");
     }
 
     @Test
     public void tryParserPrimaryName_parsesWithBestEffort() {
-        assertThat(UserAgents.tryParsePrimaryName(null)).isEqualTo("unknown");
-        assertThat(UserAgents.tryParsePrimaryName("")).isEqualTo("unknown");
-        assertThat(UserAgents.tryParsePrimaryName("a")).isEqualTo("unknown");
-
-        assertThat(UserAgents.tryParsePrimaryName("serviceA|1.2.3")).isEqualTo("unknown");
-        assertThat(UserAgents.tryParsePrimaryName("foo serviceA/1.2.3")).isEqualTo("serviceA");
-        assertThat(UserAgents.tryParsePrimaryName("foo&serviceA/1.2.3")).isEqualTo("serviceA");
-        assertThat(UserAgents.tryParsePrimaryName("serviceA/1.2.3 bogus|1.2.3 foo bar (boom)"))
-                .isEqualTo("serviceA");
-        assertThat(UserAgents.tryParsePrimaryName("foo bar baz serviceA/1.2.3 (some stuff)"))
-                .isEqualTo("serviceA");
-        assertThat(UserAgents.tryParsePrimaryName(" serviceA/1.2.3")).isEqualTo("serviceA");
-        assertThat(UserAgents.tryParsePrimaryName("\tserviceA/1.2.3")).isEqualTo("serviceA");
-        assertThat(UserAgents.tryParsePrimaryName("&/1.2.3")).isEqualTo("unknown");
+        validateTryParsePrimaryName(null, "unknown");
+        validateTryParsePrimaryName("", "unknown");
+        validateTryParsePrimaryName("a", "unknown");
+        validateTryParsePrimaryName("serviceA|1.2.3", "unknown");
+        validateTryParsePrimaryName("foo serviceA/1.2.3", "serviceA");
+        validateTryParsePrimaryName("foo&serviceA/1.2.3", "serviceA");
+        validateTryParsePrimaryName("serviceA/1.2.3 bogus|1.2.3 foo bar (boom)", "serviceA");
+        validateTryParsePrimaryName("foo bar baz serviceA/1.2.3 (some stuff)", "serviceA");
+        validateTryParsePrimaryName(" serviceA/1.2.3", "serviceA");
+        validateTryParsePrimaryName("\tserviceA/1.2.3", "serviceA");
+        validateTryParsePrimaryName("&/1.2.3", "unknown");
 
         // tryParsePrimaryName explicitly tries to avoid doing extra work like parsing a version string, which
         // relies on a regex match that could be expensive (and we're not interested in it anyway)
         // this means calls can sometimes have unintended behavior for a user-agent string that's not well formed,
         // but that's probably okay for most use cases
+        // assertThat(UserAgents.tryParsePrimaryName("foo/")).isEqualTo("foo");
+        validateTryParsePrimaryName("foo/", "foo");
+    }
+
+    @Test
+    public void tryParsePrimaryName_stillParsesOnInvalidUserAgentString() {
+        // tryParsePrimaryName explicitly tries to avoid doing extra work like parsing a version string, which
+        // relies on a regex match that could be expensive (and we're not interested in it anyway)
+        // this means calls can sometimes have unintended behavior for a user-agent string that's not well formed,
+        // but that's probably okay for most use cases.
+
+        // note that this is distinct from calling UserAgents.tryParse("foo/").primary().name(), which would return
+        // "unknown"
         assertThat(UserAgents.tryParsePrimaryName("foo/")).isEqualTo("foo");
+    }
+
+    // validates that UserAgents.tryParsePrimaryName both:
+    //    - matches the expected primary name output
+    //    - matches the output of UserAgents.tryParse(input).primary().name()
+    private static void validateTryParsePrimaryName(String userAgent, String expectedResult) {
+        assertThat(UserAgents.tryParsePrimaryName(userAgent)).isEqualTo(expectedResult);
+        assertThat(UserAgents.tryParsePrimaryName(userAgent))
+                .isEqualTo(UserAgents.tryParse(userAgent).primary().name());
     }
 
     @Test

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -190,10 +190,42 @@ public class UserAgentTest {
         assertThat(UserAgents.format(UserAgents.tryParse(""))).isEqualTo("unknown/0.0.0");
         assertThat(UserAgents.format(UserAgents.tryParse("serviceA|1.2.3"))).isEqualTo("unknown/0.0.0");
         assertThat(UserAgents.format(UserAgents.tryParse("foo serviceA/1.2.3"))).isEqualTo("serviceA/1.2.3");
+        assertThat(UserAgents.format(UserAgents.tryParse("foo&serviceA/1.2.3"))).isEqualTo("serviceA/1.2.3");
 
         // Omits malformed informational agents
         assertThat(UserAgents.format(UserAgents.tryParse("serviceA/1.2.3 bogus|1.2.3 foo bar (boom)")))
                 .isEqualTo("serviceA/1.2.3");
+    }
+
+    @Test
+    public void tryParsePrimaryName_ignoresExtraStuff() {
+        assertThat(UserAgents.tryParsePrimaryName("serviceA/1.2.3")).isEqualTo("serviceA");
+        assertThat(UserAgents.tryParsePrimaryName("serviceA/1.2.3 (foobar)")).isEqualTo("serviceA");
+        assertThat(UserAgents.tryParsePrimaryName("serviceA/1.2.3 serviceB/4.5.6 (foobar fizz buzz"))
+                .isEqualTo("serviceA");
+    }
+
+    @Test
+    public void tryParserPrimaryName_parsesWithBestEffort() {
+        assertThat(UserAgents.tryParsePrimaryName(null)).isEqualTo("unknown");
+        assertThat(UserAgents.tryParsePrimaryName("")).isEqualTo("unknown");
+        assertThat(UserAgents.tryParsePrimaryName("a")).isEqualTo("unknown");
+
+        assertThat(UserAgents.tryParsePrimaryName("serviceA|1.2.3")).isEqualTo("unknown");
+        assertThat(UserAgents.tryParsePrimaryName("foo serviceA/1.2.3")).isEqualTo("serviceA");
+        assertThat(UserAgents.tryParsePrimaryName("foo&serviceA/1.2.3")).isEqualTo("serviceA");
+        assertThat(UserAgents.tryParsePrimaryName("serviceA/1.2.3 bogus|1.2.3 foo bar (boom)"))
+                .isEqualTo("serviceA");
+        assertThat(UserAgents.tryParsePrimaryName("foo bar baz serviceA/1.2.3 (some stuff)"))
+                .isEqualTo("serviceA");
+        assertThat(UserAgents.tryParsePrimaryName(" serviceA/1.2.3")).isEqualTo("serviceA");
+        assertThat(UserAgents.tryParsePrimaryName("\tserviceA/1.2.3")).isEqualTo("serviceA");
+
+        // tryParsePrimaryName explicitly tries to avoid doing extra work like parsing a version string, which
+        // relies on a regex match that could be expensive (and we're not interested in it anyway)
+        // this means calls can sometimes have unintended behavior for a user-agent string that's not well formed,
+        // but that's probably okay for most use cases
+        assertThat(UserAgents.tryParsePrimaryName("foo/")).isEqualTo("foo");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Some codepaths parse a user-agent string, but are only interested in the value of `UserAgents.tryParse(input).primary().name()`. Parsing the entire user-agent string can be somewhat expensive in this case, since it involves matching against multiple regular expressions, when in reality the caller is only interested in the string that immediately preceded the first `'/'` character in the string.

Note that there _is_ an existing fast-path for checking for a valid `name()` (which we re-use here) that avoids regular expressions, but the version number is still matched against a regex, and the entire parsing logic still relies on iterating over regex matches to pull out individual user-agent strings in the input, which is unnecessary in this case.

## After this PR
Adds a method `UserAgents#tryParsePrimaryName`, which attempts to parse and return _only_ the "name" component of the primary user-agent, and ignores everything else. It tries to be faster by explicitly not doing any regular expression matching and only examining a subset of the user-agent string (up to the very first "/" character).

==COMMIT_MSG==
faster parsing for primary name component of user-agent strings
==COMMIT_MSG==

## Possible downsides?
This is fairly specialized; it's debatable whether or not it belongs in the public API here, but it's helpful to re-use the fast-path that checks for valid name characters to ensure the result matches what `UserAgents.tryParse(input).primary().name()` would return.

Note that `UserAgents#tryParsePrimaryName` may have unintended results when given a user-agent string without any version number (e.g. the string `"foo/"`); it will return `foo`, even though `UserAgents#tryParse` would return `unknown/0.0.0` since it did not find a valid version number.

