### PR TITLE
Optimize UserAgents

### DIFF
--- a/changelog/@unreleased/pr-1283.v2.yml
+++ b/changelog/@unreleased/pr-1283.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid regex capturing groups and regex split
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1283

--- a/service-config/build.gradle
+++ b/service-config/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api "com.palantir.safe-logging:safe-logging"
     api "com.palantir.safe-logging:preconditions"
     api "com.palantir.tokens:auth-tokens"
+    implementation "com.google.guava:guava"
     implementation "com.palantir.safe-logging:logger"
 
     testImplementation project(":extras:jackson-support")

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -45,10 +45,8 @@ public final class UserAgents {
             Pattern.compile("^[0-9]+(?:\\.[0-9]+)*(?:-rc[0-9]+)?(?:-[0-9]+-g[a-f0-9]+)?$");
     private static final Pattern SEGMENT_PATTERN =
             Pattern.compile(String.format("(%s)/(%s)( \\((.+?)\\))?", NAME_REGEX, LENIENT_VERSION_REGEX));
-    private static final Splitter COMMA_OR_SEMICOLON_SPLITTER = Splitter.on(
-                    CharMatcher.anyOf(",;").precomputed())
-            .omitEmptyStrings()
-            .trimResults();
+    private static final Splitter COMMA_OR_SEMICOLON_SPLITTER =
+            Splitter.on(CharMatcher.anyOf(",;").precomputed()).trimResults().omitEmptyStrings();
 
     private UserAgents() {}
 

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -16,6 +16,8 @@
 
 package com.palantir.conjure.java.api.config.service;
 
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
@@ -40,9 +42,13 @@ public final class UserAgents {
     private static final Pattern LENIENT_VERSION_REGEX = Pattern.compile("[0-9a-z.-]+");
     private static final Pattern NODE_REGEX = Pattern.compile("[a-zA-Z0-9][a-zA-Z0-9.\\-]*");
     private static final Pattern VERSION_REGEX =
-            Pattern.compile("^[0-9]+(\\.[0-9]+)*(-rc[0-9]+)?(-[0-9]+-g[a-f0-9]+)?$");
+            Pattern.compile("^[0-9]+(?:\\.[0-9]+)*(?:-rc[0-9]+)?(?:-[0-9]+-g[a-f0-9]+)?$");
     private static final Pattern SEGMENT_PATTERN =
             Pattern.compile(String.format("(%s)/(%s)( \\((.+?)\\))?", NAME_REGEX, LENIENT_VERSION_REGEX));
+    private static final Splitter COMMA_OR_SEMICOLON_SPLITTER = Splitter.on(
+                    CharMatcher.anyOf(",;").precomputed())
+            .omitEmptyStrings()
+            .trimResults();
 
     private UserAgents() {}
 
@@ -175,7 +181,7 @@ public final class UserAgents {
 
     private static Map<String, String> parseComments(String commentsString) {
         Map<String, String> comments = new HashMap<>();
-        for (String comment : commentsString.split("[,;]")) {
+        for (String comment : COMMA_OR_SEMICOLON_SPLITTER.split(commentsString)) {
             String[] fields = comment.split(":");
             if (fields.length == 2) {
                 comments.put(fields[0], fields[1]);


### PR DESCRIPTION
## Before this PR

UserAgents parsing and validation used unnecessary regex capturing groups and regex split.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Avoid regex capturing groups and regex split
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

