### PR TITLE
Conjure User-Agents supports arbitrary comment data

### DIFF
--- a/changelog/@unreleased/pr-1286.v2.yml
+++ b/changelog/@unreleased/pr-1286.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Conjure User-Agents supports arbitrary comment metadata, for observability
+    metadata similar to the existing `nodeId` parameter.
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1286

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
@@ -16,10 +16,12 @@
 
 package com.palantir.conjure.java.api.config.service;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.immutables.value.Value;
 
 /**
@@ -34,13 +36,14 @@ public interface UserAgent {
     /** Identifies the node (e.g., IP address, container identifier, etc) on which this user agent was constructed. */
     @Value.Lazy
     default Optional<String> nodeId() {
-        if (comments().isEmpty()) {
+        if (primary().comments().isEmpty()) {
             // fast path to avoid stream overhead
             return Optional.empty();
         }
-        return comments().stream()
+        return primary().comments().stream()
                 .filter(item -> item.startsWith("nodeId:"))
                 .map(item -> item.substring(7).trim())
+                .filter(UserAgents::isValidNodeId)
                 .findFirst();
     }
 
@@ -53,13 +56,15 @@ public interface UserAgent {
      */
     List<Agent> informational();
 
-    List<String> comments();
-
     /** Creates a new {@link UserAgent} with the given {@link #primary} agent and originating node id. */
     static UserAgent of(Agent agent, String nodeId) {
+        UserAgents.checkNodeId(nodeId);
+        List<String> comments = Stream.concat(
+                        agent.comments().stream().filter(item -> !item.startsWith("nodeId:")),
+                        Stream.of("nodeId:" + nodeId))
+                .toList();
         return ImmutableUserAgent.builder()
-                .addComments("nodeId:" + nodeId)
-                .primary(agent)
+                .primary(Agent.of(agent.name(), agent.version(), comments))
                 .build();
     }
 
@@ -89,20 +94,6 @@ public interface UserAgent {
         return ImmutableUserAgent.builder().from(this).addInformational(agent).build();
     }
 
-    default UserAgent addComment(String comment) {
-        UserAgents.checkComment(comment);
-        return ImmutableUserAgent.builder().from(this).addComments(comment).build();
-    }
-
-    @Value.Check
-    default void check() {
-        if (nodeId().isPresent()) {
-            if (!UserAgents.isValidNodeId(nodeId().get())) {
-                throw new SafeIllegalArgumentException("Illegal node id format", SafeArg.of("nodeId", nodeId().get()));
-            }
-        }
-    }
-
     /** Specifies an agent that participates (client-side) in an RPC call in terms of its name and version. */
     @Value.Immutable
     @ImmutablesStyle
@@ -112,6 +103,8 @@ public interface UserAgent {
         String name();
 
         String version();
+
+        List<String> comments();
 
         @Value.Check
         default void check() {
@@ -129,6 +122,19 @@ public interface UserAgent {
             return ImmutableAgent.builder()
                     .name(name)
                     .version(UserAgents.isValidVersion(version) ? version : DEFAULT_VERSION)
+                    .build();
+        }
+
+        static Agent of(String name, String version, Iterable<String> comments) {
+            ImmutableList<String> immutableComments = ImmutableList.copyOf(comments);
+            for (int i = 0; i < immutableComments.size(); i++) {
+                String comment = immutableComments.get(i);
+                UserAgents.checkComment(comment);
+            }
+            return ImmutableAgent.builder()
+                    .name(name)
+                    .version(UserAgents.isValidVersion(version) ? version : DEFAULT_VERSION)
+                    .comments(immutableComments)
                     .build();
         }
     }

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.api.config.service;
 
-import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.List;
@@ -33,7 +32,17 @@ import org.immutables.value.Value;
 public interface UserAgent {
 
     /** Identifies the node (e.g., IP address, container identifier, etc) on which this user agent was constructed. */
-    Optional<String> nodeId();
+    @Value.Lazy
+    default Optional<String> nodeId() {
+        if (comments().isEmpty()) {
+            // fast path to avoid stream overhead
+            return Optional.empty();
+        }
+        return comments().stream()
+                .filter(item -> item.startsWith("nodeId:"))
+                .map(item -> item.substring(7).trim())
+                .findFirst();
+    }
 
     /** The primary user agent, typically the name/version of the service initiating an RPC call. */
     Agent primary();
@@ -44,9 +53,14 @@ public interface UserAgent {
      */
     List<Agent> informational();
 
+    List<String> comments();
+
     /** Creates a new {@link UserAgent} with the given {@link #primary} agent and originating node id. */
     static UserAgent of(Agent agent, String nodeId) {
-        return ImmutableUserAgent.builder().nodeId(nodeId).primary(agent).build();
+        return ImmutableUserAgent.builder()
+                .addComments("nodeId:" + nodeId)
+                .primary(agent)
+                .build();
     }
 
     /**
@@ -75,13 +89,17 @@ public interface UserAgent {
         return ImmutableUserAgent.builder().from(this).addInformational(agent).build();
     }
 
+    default UserAgent addComment(String comment) {
+        UserAgents.checkComment(comment);
+        return ImmutableUserAgent.builder().from(this).addComments(comment).build();
+    }
+
     @Value.Check
     default void check() {
         if (nodeId().isPresent()) {
-            Preconditions.checkArgument(
-                    UserAgents.isValidNodeId(nodeId().get()),
-                    "Illegal node id format",
-                    SafeArg.of("nodeId", nodeId().get()));
+            if (!UserAgents.isValidNodeId(nodeId().get())) {
+                throw new SafeIllegalArgumentException("Illegal node id format", SafeArg.of("nodeId", nodeId().get()));
+            }
         }
     }
 

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.api.config.service;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.List;
@@ -35,7 +36,7 @@ public interface UserAgent {
 
     /** Identifies the node (e.g., IP address, container identifier, etc) on which this user agent was constructed. */
     @Value.Lazy
-    default Optional<String> nodeId() {
+    default Optional<@Safe String> nodeId() {
         if (primary().comments().isEmpty()) {
             // fast path to avoid stream overhead
             return Optional.empty();
@@ -57,7 +58,7 @@ public interface UserAgent {
     List<Agent> informational();
 
     /** Creates a new {@link UserAgent} with the given {@link #primary} agent and originating node id. */
-    static UserAgent of(Agent agent, String nodeId) {
+    static UserAgent of(Agent agent, @Safe String nodeId) {
         UserAgents.checkNodeId(nodeId);
         List<String> comments = Stream.concat(
                         agent.comments().stream().filter(item -> !item.startsWith("nodeId:")),
@@ -97,14 +98,24 @@ public interface UserAgent {
     /** Specifies an agent that participates (client-side) in an RPC call in terms of its name and version. */
     @Value.Immutable
     @ImmutablesStyle
+    @Safe
     interface Agent {
         String DEFAULT_VERSION = "0.0.0";
 
+        @Safe
         String name();
 
+        @Safe
         String version();
 
-        List<String> comments();
+        /**
+         * <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3>rfc7231 section-5.5.3</a> comment
+         * metadata (as described by
+         * <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6">rfc7230 section-3.2.6</a>)
+         * for additional diagnostic information. Note that this library provides a much stricter set of allowed
+         * characters within comments than the linked RFCs to reduce complexity.
+         */
+        List<@Safe String> comments();
 
         @Value.Check
         default void check() {
@@ -118,14 +129,14 @@ public interface UserAgent {
             }
         }
 
-        static Agent of(String name, String version) {
+        static Agent of(@Safe String name, @Safe String version) {
             return ImmutableAgent.builder()
                     .name(name)
                     .version(UserAgents.isValidVersion(version) ? version : DEFAULT_VERSION)
                     .build();
         }
 
-        static Agent of(String name, String version, Iterable<String> comments) {
+        static Agent of(@Safe String name, @Safe String version, @Safe Iterable<@Safe String> comments) {
             ImmutableList<String> immutableComments = ImmutableList.copyOf(comments);
             for (int i = 0; i < immutableComments.size(); i++) {
                 String comment = immutableComments.get(i);

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -20,6 +20,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
@@ -56,7 +57,8 @@ public final class UserAgents {
     private UserAgents() {}
 
     /** Returns the canonical string format for the given {@link UserAgent}. */
-    public static String format(UserAgent userAgent) {
+    @Safe
+    public static String format(@Safe UserAgent userAgent) {
         StringBuilder formatted = new StringBuilder(64); // preallocate larger buffer for longer agents
         formatSimpleAgent(userAgent.primary(), formatted);
         for (UserAgent.Agent informationalAgent : userAgent.informational()) {
@@ -89,7 +91,7 @@ public final class UserAgents {
      *
      * <p>Valid user agent strings loosely follow RFC 7230 (https://tools.ietf.org/html/rfc7230#section-3.2.6).
      */
-    public static UserAgent parse(String userAgent) {
+    public static UserAgent parse(@Safe String userAgent) {
         Preconditions.checkNotNull(userAgent, "userAgent must not be null");
         return parseInternal(userAgent, false /* strict */);
     }
@@ -98,7 +100,7 @@ public final class UserAgents {
      * Like {@link #parse}, but never fails and returns the primary agent {@code unknown/0.0.0} if no valid primary
      * agent can be parsed.
      */
-    public static UserAgent tryParse(String userAgent) {
+    public static UserAgent tryParse(@Safe String userAgent) {
 
         return parseInternal(userAgent == null ? "" : userAgent, true /* lenient */);
     }
@@ -110,7 +112,7 @@ public final class UserAgents {
      * This is functionally similar to calling `tryParse(userAgent).primary().name()`, but optimized to not use
      * regular expressions.
      */
-    public static String tryParsePrimaryName(String userAgent) {
+    public static String tryParsePrimaryName(@Safe String userAgent) {
         if (userAgent == null) {
             return "unknown";
         }
@@ -145,7 +147,7 @@ public final class UserAgents {
         return userAgent.substring(lindex, split);
     }
 
-    private static UserAgent parseInternal(String userAgent, boolean lenient) {
+    private static UserAgent parseInternal(@Safe String userAgent, boolean lenient) {
         ImmutableUserAgent.Builder builder = ImmutableUserAgent.builder();
 
         Matcher matcher = SEGMENT_PATTERN.matcher(userAgent);
@@ -197,7 +199,7 @@ public final class UserAgents {
         return results;
     }
 
-    static void checkComment(String comment) {
+    static void checkComment(@Safe String comment) {
         if (comment == null) {
             throw new SafeIllegalArgumentException("Comment must not be null");
         }
@@ -220,7 +222,7 @@ public final class UserAgents {
         }
     }
 
-    static boolean isValidComment(String comment) {
+    static boolean isValidComment(@Safe String comment) {
         return comment != null
                 && !comment.isEmpty()
                 && !comment.startsWith(" ")
@@ -265,13 +267,13 @@ public final class UserAgents {
         return NODE_REGEX.matcher(instanceId).matches();
     }
 
-    static void checkNodeId(String instanceId) {
+    static void checkNodeId(@Safe String instanceId) {
         if (!isValidNodeId(instanceId)) {
             throw new SafeIllegalArgumentException("Illegal node id format", SafeArg.of("nodeId", instanceId));
         }
     }
 
-    static boolean isValidVersion(String version) {
+    static boolean isValidVersion(@Safe String version) {
         if (VersionParser.countNumericDotGroups(version) >= 2 // fast path for numeric & dot only version numbers
                 || versionMatchesRegex(version)) {
             return true;

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -23,8 +23,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -47,6 +46,11 @@ public final class UserAgents {
             Pattern.compile(String.format("(%s)/(%s)( \\((.+?)\\))?", NAME_REGEX, LENIENT_VERSION_REGEX));
     private static final Splitter COMMA_OR_SEMICOLON_SPLITTER =
             Splitter.on(CharMatcher.anyOf(",;").precomputed()).trimResults().omitEmptyStrings();
+    private static final CharMatcher COMMENT_VALID_CHARS = CharMatcher.inRange('a', 'z')
+            .or(CharMatcher.inRange('A', 'Z'))
+            .or(CharMatcher.inRange('0', '9'))
+            .or(CharMatcher.anyOf(".-:_/ "))
+            .precomputed();
 
     private UserAgents() {}
 
@@ -54,8 +58,16 @@ public final class UserAgents {
     public static String format(UserAgent userAgent) {
         StringBuilder formatted = new StringBuilder(64); // preallocate larger buffer for longer agents
         formatSimpleAgent(userAgent.primary(), formatted);
-        if (userAgent.nodeId().isPresent()) {
-            formatted.append(" (nodeId:").append(userAgent.nodeId().get()).append(')');
+        List<String> comments = userAgent.comments();
+        if (!comments.isEmpty()) {
+            formatted.append(" (");
+            for (int i = 0; i < comments.size(); i++) {
+                if (i > 0) {
+                    formatted.append("; ");
+                }
+                formatted.append(comments.get(i));
+            }
+            formatted.append(')');
         }
         for (UserAgent.Agent informationalAgent : userAgent.informational()) {
             formatted.append(' ');
@@ -146,10 +158,8 @@ public final class UserAgents {
                 // primary
                 builder.primary(UserAgent.Agent.of(name, version));
                 comments.ifPresent(c -> {
-                    Map<String, String> parsedComments = parseComments(c);
-                    if (parsedComments.containsKey("nodeId")) {
-                        builder.nodeId(parsedComments.get("nodeId"));
-                    }
+                    List<String> parsedComments = parseComments(c);
+                    builder.addAllComments(parsedComments);
                 });
             } else {
                 // informational
@@ -177,17 +187,46 @@ public final class UserAgents {
         return builder.build();
     }
 
-    private static Map<String, String> parseComments(String commentsString) {
-        Map<String, String> comments = new HashMap<>();
-        for (String comment : COMMA_OR_SEMICOLON_SPLITTER.split(commentsString)) {
-            String[] fields = comment.split(":");
-            if (fields.length == 2) {
-                comments.put(fields[0], fields[1]);
-            } else {
-                comments.put(comment, comment);
+    private static List<String> parseComments(String commentsString) {
+        List<String> results = COMMA_OR_SEMICOLON_SPLITTER.splitToList(commentsString);
+        for (int i = 0; i < results.size(); ++i) {
+            // In most cases, all comments will be valid, so we avoid stream overhead.
+            if (!isValidComment(results.get(i))) {
+                return results.stream().filter(UserAgents::isValidComment).toList();
             }
         }
-        return comments;
+        return results;
+    }
+
+    static void checkComment(String comment) {
+        if (comment == null) {
+            throw new SafeIllegalArgumentException("Comment must not be null");
+        }
+        if (comment.isEmpty()) {
+            throw new SafeIllegalArgumentException("Comment must not be empty");
+        }
+        if (comment.startsWith(" ")) {
+            throw new SafeIllegalArgumentException(
+                    "Comment must not start with whitespace", SafeArg.of("comment", comment));
+        }
+        if (comment.endsWith(" ")) {
+            throw new SafeIllegalArgumentException(
+                    "Comment must not end with whitespace", SafeArg.of("comment", comment));
+        }
+        if (!COMMENT_VALID_CHARS.matchesAllOf(comment)) {
+            throw new SafeIllegalArgumentException(
+                    "Comment contains disallowed characters",
+                    SafeArg.of("allowed", "a-zA-Z0-9.-:_/ "),
+                    SafeArg.of("comment", comment));
+        }
+    }
+
+    static boolean isValidComment(String comment) {
+        return comment != null
+                && !comment.isEmpty()
+                && !comment.startsWith(" ")
+                && !comment.endsWith(" ")
+                && COMMENT_VALID_CHARS.matchesAllOf(comment);
     }
 
     static boolean isValidName(String name) {

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -45,12 +45,12 @@ public final class UserAgents {
             Pattern.compile("^[0-9]+(?:\\.[0-9]+)*(?:-rc[0-9]+)?(?:-[0-9]+-g[a-f0-9]+)?$");
     private static final Pattern SEGMENT_PATTERN =
             Pattern.compile(String.format("(%s)/(%s)( \\((.+?)\\))?", NAME_REGEX, LENIENT_VERSION_REGEX));
-    private static final Splitter COMMA_OR_SEMICOLON_SPLITTER =
-            Splitter.on(CharMatcher.anyOf(",;").precomputed()).trimResults().omitEmptyStrings();
+    private static final Splitter SEMICOLON_SPLITTER =
+            Splitter.on(CharMatcher.is(';').precomputed()).trimResults().omitEmptyStrings();
     private static final CharMatcher COMMENT_VALID_CHARS = CharMatcher.inRange('a', 'z')
             .or(CharMatcher.inRange('A', 'Z'))
             .or(CharMatcher.inRange('0', '9'))
-            .or(CharMatcher.anyOf(".-:_/ "))
+            .or(CharMatcher.anyOf(".-:_/ ,"))
             .precomputed();
 
     private UserAgents() {}
@@ -187,7 +187,7 @@ public final class UserAgents {
     }
 
     private static List<String> parseComments(String commentsString) {
-        List<String> results = COMMA_OR_SEMICOLON_SPLITTER.splitToList(commentsString);
+        List<String> results = SEMICOLON_SPLITTER.splitToList(commentsString);
         for (int i = 0; i < results.size(); ++i) {
             // In most cases, all comments will be valid, so we avoid stream overhead.
             if (!isValidComment(results.get(i))) {

--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgents.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.api.config.service;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
@@ -58,17 +59,6 @@ public final class UserAgents {
     public static String format(UserAgent userAgent) {
         StringBuilder formatted = new StringBuilder(64); // preallocate larger buffer for longer agents
         formatSimpleAgent(userAgent.primary(), formatted);
-        List<String> comments = userAgent.comments();
-        if (!comments.isEmpty()) {
-            formatted.append(" (");
-            for (int i = 0; i < comments.size(); i++) {
-                if (i > 0) {
-                    formatted.append("; ");
-                }
-                formatted.append(comments.get(i));
-            }
-            formatted.append(')');
-        }
         for (UserAgent.Agent informationalAgent : userAgent.informational()) {
             formatted.append(' ');
             formatSimpleAgent(informationalAgent, formatted);
@@ -80,6 +70,17 @@ public final class UserAgents {
         output.ensureCapacity(
                 output.length() + 1 + agent.name().length() + agent.version().length());
         output.append(agent.name()).append('/').append(agent.version());
+        List<String> comments = agent.comments();
+        if (!comments.isEmpty()) {
+            output.append(" (");
+            for (int i = 0; i < comments.size(); i++) {
+                if (i > 0) {
+                    output.append("; ");
+                }
+                output.append(comments.get(i));
+            }
+            output.append(')');
+        }
     }
 
     /**
@@ -154,16 +155,14 @@ public final class UserAgents {
             String version = matcher.group(2);
             Optional<String> comments = Optional.ofNullable(matcher.group(4));
 
+            UserAgent.Agent agent = UserAgent.Agent.of(
+                    name, version, comments.map(UserAgents::parseComments).orElseGet(ImmutableList::of));
             if (!foundFirst) {
                 // primary
-                builder.primary(UserAgent.Agent.of(name, version));
-                comments.ifPresent(c -> {
-                    List<String> parsedComments = parseComments(c);
-                    builder.addAllComments(parsedComments);
-                });
+                builder.primary(agent);
             } else {
                 // informational
-                builder.addInformational(UserAgent.Agent.of(name, version));
+                builder.addInformational(agent);
             }
 
             foundFirst = true;
@@ -264,6 +263,12 @@ public final class UserAgents {
 
     static boolean isValidNodeId(String instanceId) {
         return NODE_REGEX.matcher(instanceId).matches();
+    }
+
+    static void checkNodeId(String instanceId) {
+        if (!isValidNodeId(instanceId)) {
+            throw new SafeIllegalArgumentException("Illegal node id format", SafeArg.of("nodeId", instanceId));
+        }
     }
 
     static boolean isValidVersion(String version) {

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -25,7 +25,10 @@ import com.google.common.collect.Iterables;
 import com.palantir.conjure.java.api.config.service.UserAgent.Agent;
 import com.palantir.logsafe.SafeArg;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class UserAgentTest {
 
@@ -158,9 +161,12 @@ public class UserAgentTest {
                     .isEqualTo(agent);
         }
 
-        // nodeId on informational agents is omitted
-        assertThat(UserAgents.format(UserAgents.parse("serviceA/1.2.3 serviceB/4.5.6 (nodeId:myNode)")))
-                .isEqualTo("serviceA/1.2.3 serviceB/4.5.6");
+        // nodeId on informational agents is retained
+        UserAgent nodeIdOnInformational = UserAgents.parse("serviceA/1.2.3 serviceB/4.5.6 (nodeId:myNode)");
+        assertThat(UserAgents.format(nodeIdOnInformational)).isEqualTo("serviceA/1.2.3 serviceB/4.5.6 (nodeId:myNode)");
+        assertThat(nodeIdOnInformational.nodeId())
+                .as("Only primary agents nodeId should be reported")
+                .isEmpty();
 
         // Malformed informational agents are omitted
         assertThat(UserAgents.format(UserAgents.parse("serviceA/1.2.3 serviceB|4.5.6")))
@@ -171,17 +177,18 @@ public class UserAgentTest {
     public void parse_canParseBrowserAgent() {
         String chrome = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) "
                 + "Chrome/61.0.3163.100 Safari/537.36";
-        String expected =
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 Chrome/61.0.3163.100 Safari/537.36";
+        // Note the delimiter recombination from 'KHTML, like Gecko' to 'KHTML; like Gecko' because we split on
+        // both comma and semicolon.
+        String expected = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML; like Gecko) "
+                + "Chrome/61.0.3163.100 Safari/537.36";
         assertThat(UserAgents.format(UserAgents.tryParse(chrome))).isEqualTo(expected);
         assertThat(UserAgents.format(UserAgents.parse(chrome))).isEqualTo(expected);
     }
 
     @Test
     public void parse_canParseBrowserAgentWithEmptyComment() {
-        String chrome =
-                "Mozilla/5.0 ( ) AppleWebKit/537.36 (KHTML, like Gecko) " + "Chrome/61.0.3163.100 Safari/537.36";
-        String expected = "Mozilla/5.0 AppleWebKit/537.36 Chrome/61.0.3163.100 Safari/537.36";
+        String chrome = "Mozilla/5.0 ( ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36";
+        String expected = "Mozilla/5.0 AppleWebKit/537.36 (KHTML; like Gecko) Chrome/61.0.3163.100 Safari/537.36";
         assertThat(UserAgents.format(UserAgents.tryParse(chrome))).isEqualTo(expected);
         assertThat(UserAgents.format(UserAgents.parse(chrome))).isEqualTo(expected);
     }
@@ -267,28 +274,60 @@ public class UserAgentTest {
     }
 
     @Test
-    public void invalid_comment() {
-        UserAgent agent = UserAgent.of(Agent.of("name", "0.0.0"));
-        assertThatThrownBy(() -> agent.addComment(";"))
+    public void invalid_comment_messages() {
+        assertThatThrownBy(() -> UserAgents.checkComment(";"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Comment contains disallowed characters");
         assertThat(UserAgents.isValidComment(";")).isFalse();
-        assertThatThrownBy(() -> agent.addComment(null))
+        assertThatThrownBy(() -> UserAgents.checkComment(null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Comment must not be null");
         assertThat(UserAgents.isValidComment(null)).isFalse();
-        assertThatThrownBy(() -> agent.addComment(""))
+        assertThatThrownBy(() -> UserAgents.checkComment(""))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Comment must not be empty");
         assertThat(UserAgents.isValidComment("")).isFalse();
-        assertThatThrownBy(() -> agent.addComment(" leading whitespace"))
+        assertThatThrownBy(() -> UserAgents.checkComment(" leading whitespace"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Comment must not start with whitespace");
         assertThat(UserAgents.isValidComment(" leading whitespace")).isFalse();
-        assertThatThrownBy(() -> agent.addComment("trailing whitespace "))
+        assertThatThrownBy(() -> UserAgents.checkComment("trailing whitespace "))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Comment must not end with whitespace");
         assertThat(UserAgents.isValidComment("trailing whitespace ")).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"nodeId:nodeId", "MyResource/ri.abc.def.ghi-jkl"})
+    public void valid_comments(String comment) {
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(UserAgents.isValidComment(comment)).isTrue();
+        softly.assertThatCode(() -> UserAgents.checkComment(comment)).doesNotThrowAnyException();
+        softly.assertAll();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {";", "", " leading", "trailing ", "(parens)"})
+    public void invalid_comments(String comment) {
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(UserAgents.isValidComment(comment)).isFalse();
+        softly.assertThatThrownBy(() -> UserAgents.checkComment(comment)).isInstanceOf(IllegalArgumentException.class);
+        softly.assertAll();
+    }
+
+    @Test
+    public void testNodeIdReplacement() {
+        UserAgent original = UserAgent.of(Agent.of("name", "0.0.0"), "nodeId1");
+        UserAgent replacement = UserAgent.of(original.primary(), "nodeId2");
+        assertThat(UserAgents.format(replacement)).isEqualTo("name/0.0.0 (nodeId:nodeId2)");
+    }
+
+    @Test
+    public void testNodeIdOnInformationalAgent() {
+        UserAgent original = UserAgent.of(Agent.of("primary", "0.0.0"), "nodeId1");
+        UserAgent updated = original.addAgent(
+                UserAgent.of(Agent.of("info", "0.0.0"), "nodeId2").primary());
+        assertThat(UserAgents.format(updated)).isEqualTo("primary/0.0.0 (nodeId:nodeId1) info/0.0.0 (nodeId:nodeId2)");
     }
 
     private static void isValidName(String name) {

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.api.config.service;
 
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -119,14 +120,15 @@ public class UserAgentTest {
             "service/10.20.30",
             "service/10.20.30 (nodeId:myNode)",
         }) {
-            assertThat(UserAgents.format(UserAgents.parse(agent)))
-                    .withFailMessage(agent)
-                    .isEqualTo(agent);
+            assertThat(UserAgents.format(UserAgents.parse(agent))).isEqualTo(agent);
         }
 
-        // Formatting ignores non-nodeId comments
+        // Formatting ignores invalid comments
+        assertThat(UserAgents.format(UserAgents.parse("service/1.2.3 (())"))).isEqualTo("service/1.2.3");
+
+        // Formatting retains valid comments
         assertThat(UserAgents.format(UserAgents.parse("service/1.2.3 (foo:bar)")))
-                .isEqualTo("service/1.2.3");
+                .isEqualTo("service/1.2.3 (foo:bar)");
 
         // Finds primary agent even when there is a prefix
         assertThat(UserAgents.format(UserAgents.parse("  service/1.2.3"))).isEqualTo("service/1.2.3");
@@ -169,7 +171,8 @@ public class UserAgentTest {
     public void parse_canParseBrowserAgent() {
         String chrome = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) "
                 + "Chrome/61.0.3163.100 Safari/537.36";
-        String expected = "Mozilla/5.0 AppleWebKit/537.36 Chrome/61.0.3163.100 Safari/537.36";
+        String expected =
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 Chrome/61.0.3163.100 Safari/537.36";
         assertThat(UserAgents.format(UserAgents.tryParse(chrome))).isEqualTo(expected);
         assertThat(UserAgents.format(UserAgents.parse(chrome))).isEqualTo(expected);
     }
@@ -261,6 +264,31 @@ public class UserAgentTest {
         assertThat("service name").satisfies(UserAgentTest::isNotValidName);
         assertThat("service.name").satisfies(UserAgentTest::isNotValidName);
         assertThat("service_name").satisfies(UserAgentTest::isNotValidName);
+    }
+
+    @Test
+    public void invalid_comment() {
+        UserAgent agent = UserAgent.of(Agent.of("name", "0.0.0"));
+        assertThatThrownBy(() -> agent.addComment(";"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Comment contains disallowed characters");
+        assertThat(UserAgents.isValidComment(";")).isFalse();
+        assertThatThrownBy(() -> agent.addComment(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Comment must not be null");
+        assertThat(UserAgents.isValidComment(null)).isFalse();
+        assertThatThrownBy(() -> agent.addComment(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Comment must not be empty");
+        assertThat(UserAgents.isValidComment("")).isFalse();
+        assertThatThrownBy(() -> agent.addComment(" leading whitespace"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Comment must not start with whitespace");
+        assertThat(UserAgents.isValidComment(" leading whitespace")).isFalse();
+        assertThatThrownBy(() -> agent.addComment("trailing whitespace "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Comment must not end with whitespace");
+        assertThat(UserAgents.isValidComment("trailing whitespace ")).isFalse();
     }
 
     private static void isValidName(String name) {

--- a/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
+++ b/service-config/src/test/java/com/palantir/conjure/java/api/config/service/UserAgentTest.java
@@ -177,9 +177,7 @@ public class UserAgentTest {
     public void parse_canParseBrowserAgent() {
         String chrome = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) "
                 + "Chrome/61.0.3163.100 Safari/537.36";
-        // Note the delimiter recombination from 'KHTML, like Gecko' to 'KHTML; like Gecko' because we split on
-        // both comma and semicolon.
-        String expected = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML; like Gecko) "
+        String expected = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) "
                 + "Chrome/61.0.3163.100 Safari/537.36";
         assertThat(UserAgents.format(UserAgents.tryParse(chrome))).isEqualTo(expected);
         assertThat(UserAgents.format(UserAgents.parse(chrome))).isEqualTo(expected);
@@ -188,7 +186,7 @@ public class UserAgentTest {
     @Test
     public void parse_canParseBrowserAgentWithEmptyComment() {
         String chrome = "Mozilla/5.0 ( ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36";
-        String expected = "Mozilla/5.0 AppleWebKit/537.36 (KHTML; like Gecko) Chrome/61.0.3163.100 Safari/537.36";
+        String expected = "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36";
         assertThat(UserAgents.format(UserAgents.tryParse(chrome))).isEqualTo(expected);
         assertThat(UserAgents.format(UserAgents.parse(chrome))).isEqualTo(expected);
     }
@@ -298,7 +296,7 @@ public class UserAgentTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"nodeId:nodeId", "MyResource/ri.abc.def.ghi-jkl"})
+    @ValueSource(strings = {"nodeId:nodeId", "MyResource/ri.abc.def.ghi-jkl", "KHTML, like Gecko"})
     public void valid_comments(String comment) {
         SoftAssertions softly = new SoftAssertions();
         softly.assertThat(UserAgents.isValidComment(comment)).isTrue();


### PR DESCRIPTION
This allows us to track more specific context through the platform

==COMMIT_MSG==
Conjure User-Agents supports arbitrary comment data
==COMMIT_MSG==

I need to put some more thought into this. A few areas where I think we may want to do things differently:

* I've replaced `nodeId` with `comments`, which can take multiple arbitrary values. `nodeId` was set on the top-level UserAgent, not on a per-agent basis, so the new comments are set on the top-level type and encoded just after the primary agent as well. I think we should move the comments to `Agent` instead, allowing each component to provide context.
* I'm encoding the comments as a list of strings. In practice the user-agent rfc considers the comment a single value, but we should be more prescriptive. We could require key-value pairs, as I expect that will be how most of these comments are used (much like nodeId), however there are quite a few examples in the wild where segments don't map nicely to key/value pairs. Each segment may have its own preferred delimiters/sequences/etc.

In general, I like that we retain more of the original info from browser user-agents, which might not be possible if we force key/value pairs. We could bias the API toward key/value pairs in a way that doesn't exclude other strings (e.g. empty value to represent a single string) but that would make parsing more complex and risk mutations when we parse->re-encode (e.g. delimiter characters in the comment key getting split, and moving into the value)