### PR TITLE
Add endpoint service exception test util

### DIFF
--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/AssertableArgs.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/AssertableArgs.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.testing;
+
+import com.palantir.logsafe.Arg;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility to collect safe and unsafe arguments into separate collections and assert unique entries in each.
+ */
+record AssertableArgs(Map<String, Object> safeArgs, Map<String, Object> unsafeArgs) {
+
+    AssertableArgs(List<Arg<?>> args) {
+        this(new HashMap<>(), new HashMap<>());
+
+        args.forEach(arg -> {
+            if (arg.isSafeForLogging()) {
+                assertPutSafe(arg);
+            } else {
+                assertPutUnsafe(arg);
+            }
+        });
+    }
+
+    private void assertPutSafe(Arg<?> arg) {
+        assertPut(safeArgs, arg.getName(), arg.getValue(), "safe");
+    }
+
+    private void assertPutUnsafe(Arg<?> arg) {
+        assertPut(unsafeArgs, arg.getName(), arg.getValue(), "unsafe");
+    }
+
+    private static void assertPut(Map<String, Object> map, String key, Object value, String name) {
+        Object previous = map.put(key, value);
+        if (previous != null) {
+            throw new AssertionError(String.format(
+                    "Duplicate %s arg name '%s', first value: %s, second value: %s", name, key, previous, value));
+        }
+    }
+}

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.api.testing;
 
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
@@ -40,6 +41,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new QosExceptionAssert(actual);
     }
 
+    public static EndpointServiceExceptionAssert assertThat(EndpointServiceException actual) {
+        return new EndpointServiceExceptionAssert(actual);
+    }
+
     @CanIgnoreReturnValue
     public static ServiceExceptionAssert assertThatServiceExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
         return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(ServiceExceptionAssert.instanceOfAssertFactory());
@@ -53,5 +58,12 @@ public class Assertions extends org.assertj.core.api.Assertions {
     @CanIgnoreReturnValue
     public static QosExceptionAssert assertThatQosExceptionThrownBy(ThrowingCallable shouldRaiseThrowable) {
         return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(QosExceptionAssert.instanceOfAssertFactory());
+    }
+
+    @CanIgnoreReturnValue
+    public static EndpointServiceExceptionAssert assertThatEndpointServiceExceptionThrownBy(
+            ThrowingCallable shouldRaiseThrowable) {
+        return assertThatThrownBy(shouldRaiseThrowable)
+                .asInstanceOf(EndpointServiceExceptionAssert.instanceOfAssertFactory());
     }
 }

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/EndpointServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/EndpointServiceExceptionAssert.java
@@ -1,47 +1,33 @@
-/*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.palantir.conjure.java.api.testing;
 
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
 import com.palantir.conjure.java.api.errors.ErrorType;
-import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.Arg;
-import org.assertj.core.api.AbstractThrowableAssert;
-import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.util.Throwables;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.util.Throwables;
 
-public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExceptionAssert, ServiceException> {
+public class EndpointServiceExceptionAssert
+        extends AbstractThrowableAssert<EndpointServiceExceptionAssert, EndpointServiceException> {
 
-    private static final InstanceOfAssertFactory<ServiceException, ServiceExceptionAssert> INSTANCE_OF_ASSERT_FACTORY =
-            new InstanceOfAssertFactory<>(ServiceException.class, ServiceExceptionAssert::new);
+    private static final InstanceOfAssertFactory<EndpointServiceException, EndpointServiceExceptionAssert>
+            INSTANCE_OF_ASSERT_FACTORY =
+                    new InstanceOfAssertFactory<>(EndpointServiceException.class, EndpointServiceExceptionAssert::new);
 
-    ServiceExceptionAssert(ServiceException actual) {
-        super(actual, ServiceExceptionAssert.class);
+    EndpointServiceExceptionAssert(EndpointServiceException actual) {
+        super(actual, EndpointServiceExceptionAssert.class);
     }
 
-    public static InstanceOfAssertFactory<ServiceException, ServiceExceptionAssert> instanceOfAssertFactory() {
+    public static InstanceOfAssertFactory<EndpointServiceException, EndpointServiceExceptionAssert>
+            instanceOfAssertFactory() {
         return INSTANCE_OF_ASSERT_FACTORY;
     }
 
-    public final ServiceExceptionAssert hasCode(ErrorType.Code code) {
+    public final EndpointServiceExceptionAssert hasCode(ErrorType.Code code) {
         isNotNull();
         failIfNotEqual(
                 "Expected ErrorType.Code to be %s, but found %s",
@@ -49,13 +35,13 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         return this;
     }
 
-    public final ServiceExceptionAssert hasType(ErrorType type) {
+    public final EndpointServiceExceptionAssert hasType(ErrorType type) {
         isNotNull();
         failIfNotEqual("Expected ErrorType to be %s, but found %s", type, actual.getErrorType());
         return this;
     }
 
-    public final ServiceExceptionAssert hasArgs(Arg<?>... args) {
+    public final EndpointServiceExceptionAssert hasArgs(Arg<?>... args) {
         isNotNull();
 
         AssertableArgs actualArgs = new AssertableArgs(actual.getArgs());
@@ -68,7 +54,7 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         return this;
     }
 
-    public final ServiceExceptionAssert hasNoArgs() {
+    public final EndpointServiceExceptionAssert hasNoArgs() {
         isNotNull();
 
         AssertableArgs actualArgs = new AssertableArgs(actual.getArgs());
@@ -90,7 +76,7 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         }
     }
 
-    public final ServiceExceptionAssert containsArgs(Arg<?>... args) {
+    public final EndpointServiceExceptionAssert containsArgs(Arg<?>... args) {
         isNotNull();
 
         AssertableArgs actualArgs = new AssertableArgs(actual.getArgs());

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
@@ -16,11 +16,13 @@
 
 package com.palantir.conjure.java.api.testing;
 
+import static com.palantir.conjure.java.api.testing.Assertions.assertThatEndpointServiceExceptionThrownBy;
 import static com.palantir.conjure.java.api.testing.Assertions.assertThatQosExceptionThrownBy;
 import static com.palantir.conjure.java.api.testing.Assertions.assertThatRemoteExceptionThrownBy;
 import static com.palantir.conjure.java.api.testing.Assertions.assertThatServiceExceptionThrownBy;
 import static com.palantir.conjure.java.api.testing.Assertions.assertThatThrownBy;
 
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.QosReason;
@@ -112,5 +114,32 @@ public final class AssertionsTest {
                     throw QosException.unavailable(QosReason.of("reason"));
                 })
                 .hasReason(QosReason.of("reason"));
+    }
+
+    @Test
+    public void testAssertThatEndpointServiceExceptionThrownBy_failsIfNothingThrown() {
+        assertThatThrownBy(() -> assertThatEndpointServiceExceptionThrownBy(() -> {
+                    // Not going to throw anything
+                }))
+                .hasMessageContaining("Expecting code to raise a throwable.");
+    }
+
+    @Test
+    public void testAssertThatEndpointServiceExceptionThrownBy_failsIfWrongExceptionThrown() {
+        assertThatThrownBy(() -> assertThatEndpointServiceExceptionThrownBy(() -> {
+                    throw new RuntimeException("My message");
+                }))
+                .hasMessageContaining(
+                        "com.palantir.conjure.java.api.errors.EndpointServiceException",
+                        "java.lang.RuntimeException",
+                        "My message");
+    }
+
+    @Test
+    public void testAssertThatEndpointServiceExceptionThrownBy_catchesEndpointServiceException() {
+        assertThatEndpointServiceExceptionThrownBy(() -> {
+                    throw new EndpointServiceException(ErrorType.INTERNAL) {};
+                })
+                .hasType(ErrorType.INTERNAL);
     }
 }

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/EndpointServiceExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/EndpointServiceExceptionAssertTest.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.testing;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import org.junit.jupiter.api.Test;
+
+public class EndpointServiceExceptionAssertTest {
+
+    @Test
+    public void testSanity() {
+        ErrorType actualType = ErrorType.FAILED_PRECONDITION;
+
+        Assertions.assertThat(new EndpointServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")) {})
+                .hasCode(actualType.code())
+                .hasType(actualType)
+                .hasArgs(SafeArg.of("a", "b"), UnsafeArg.of("c", "d"));
+
+        Assertions.assertThat(new EndpointServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")) {})
+                .hasCode(actualType.code())
+                .hasType(actualType)
+                .hasArgs(UnsafeArg.of("c", "d"), SafeArg.of("a", "b")); // Order doesn't matter
+
+        Assertions.assertThat(new EndpointServiceException(actualType) {}).hasNoArgs();
+
+        assertThatThrownBy(() ->
+                        Assertions.assertThat(new EndpointServiceException(actualType) {}).hasCode(ErrorType.Code.INTERNAL))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining(
+                        "Expected ErrorType.Code to be %s, but found %s", ErrorType.Code.INTERNAL, actualType.code());
+
+        assertThatThrownBy(() ->
+                        Assertions.assertThat(new ServiceException(actualType)).hasType(ErrorType.INTERNAL))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected ErrorType to be %s, but found %s", ErrorType.INTERNAL, actualType);
+
+        assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b")))
+                        .hasArgs(SafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected safe args to be {c=d}, but found {a=b}");
+
+        assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b")))
+                        .hasArgs(UnsafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected unsafe args to be {c=d}, but found {a=b}");
+
+        assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b")))
+                        .hasNoArgs())
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected no args, but found {a=b}");
+
+        assertThatThrownBy(() -> Assertions.assertThat(
+                                new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                        .hasNoArgs())
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected no args, but found {a=b, c=d}");
+
+        Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                .containsArgs(UnsafeArg.of("a", "b"));
+
+        // Safety matters
+        assertThatThrownBy(() -> Assertions.assertThat(
+                                new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                        .containsArgs(UnsafeArg.of("a", "b")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected unsafe args to contain {a=b}, but found {c=d}");
+
+        assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b")))
+                        .containsArgs(SafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected safe args to contain {c=d}, but found {a=b}");
+
+        assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b")))
+                        .containsArgs(UnsafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected unsafe args to contain {c=d}, but found {a=b}");
+    }
+}


### PR DESCRIPTION
We began tagging errors in OMS as endpoint errors and thus wish to cleanly swap out `assertServiceExceptionThrownBy` with `assertEndpointServiceExceptionThrownBy`. I have duplicated this utility temporarily within OMS, but want to push this down into the library.

I did not see any easy way to combine `EndpointServiceExceptionAssert` and `ServiceExceptionAssert` since there is no relation between `ServiceException` and `EndpointServiceException`. Thoughts?