### PR TITLE
Add `AbstractServiceError` and extend `ServiceExceptionAssert` to support `EndpointServiceException`

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/AbstractServiceError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/AbstractServiceError.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.logsafe.SafeLoggable;
+
+/**
+ * This class should not be used directly. The parent class for ServiceException and EndpointServiceException.
+ */
+public abstract class AbstractServiceError extends RuntimeException implements SafeLoggable {
+    public abstract ErrorType getErrorType();
+
+    protected AbstractServiceError(Throwable cause) {
+        super(cause);
+    }
+}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/EndpointServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/EndpointServiceException.java
@@ -17,7 +17,6 @@
 package com.palantir.conjure.java.api.errors;
 
 import com.palantir.logsafe.Arg;
-import com.palantir.logsafe.SafeLoggable;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -25,7 +24,7 @@ import javax.annotation.Nullable;
  * This is identical to ServiceException, but is used in Conjure-generated code to indicate that an exception was thrown
  * from a service endpoint.
  */
-public abstract class EndpointServiceException extends RuntimeException implements SafeLoggable {
+public abstract class EndpointServiceException extends AbstractServiceError {
     private static final String EXCEPTION_NAME = "EndpointServiceException";
     private final ErrorType errorType;
     private final List<Arg<?>> args; // This is an unmodifiable list.
@@ -52,6 +51,7 @@ public abstract class EndpointServiceException extends RuntimeException implemen
     }
 
     /** The {@link ErrorType} that gave rise to this exception. */
+    @Override
     public final ErrorType getErrorType() {
         return errorType;
     }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ServiceException.java
@@ -17,12 +17,11 @@
 package com.palantir.conjure.java.api.errors;
 
 import com.palantir.logsafe.Arg;
-import com.palantir.logsafe.SafeLoggable;
 import java.util.List;
 import javax.annotation.Nullable;
 
 /** A {@link ServiceException} thrown in server-side code to indicate server-side {@link ErrorType error states}. */
-public final class ServiceException extends RuntimeException implements SafeLoggable {
+public final class ServiceException extends AbstractServiceError {
     private static final String EXCEPTION_NAME = "ServiceException";
     private final ErrorType errorType;
     private final List<Arg<?>> args; // unmodifiable
@@ -53,6 +52,7 @@ public final class ServiceException extends RuntimeException implements SafeLogg
     }
 
     /** The {@link ErrorType} that gave rise to this exception. */
+    @Override
     public ErrorType getErrorType() {
         return errorType;
     }

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/Assertions.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.api.testing;
 
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
@@ -29,6 +30,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
     Assertions() {}
 
     public static ServiceExceptionAssert assertThat(ServiceException actual) {
+        return new ServiceExceptionAssert(actual);
+    }
+
+    public static ServiceExceptionAssert assertThat(EndpointServiceException actual) {
         return new ServiceExceptionAssert(actual);
     }
 

--- a/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssert.java
@@ -16,8 +16,8 @@
 
 package com.palantir.conjure.java.api.testing;
 
+import com.palantir.conjure.java.api.errors.AbstractServiceError;
 import com.palantir.conjure.java.api.errors.ErrorType;
-import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.Arg;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -28,16 +28,17 @@ import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.util.Throwables;
 
-public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExceptionAssert, ServiceException> {
+public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExceptionAssert, AbstractServiceError> {
 
-    private static final InstanceOfAssertFactory<ServiceException, ServiceExceptionAssert> INSTANCE_OF_ASSERT_FACTORY =
-            new InstanceOfAssertFactory<>(ServiceException.class, ServiceExceptionAssert::new);
+    private static final InstanceOfAssertFactory<AbstractServiceError, ServiceExceptionAssert>
+            INSTANCE_OF_ASSERT_FACTORY =
+                    new InstanceOfAssertFactory<>(AbstractServiceError.class, ServiceExceptionAssert::new);
 
-    ServiceExceptionAssert(ServiceException actual) {
+    ServiceExceptionAssert(AbstractServiceError actual) {
         super(actual, ServiceExceptionAssert.class);
     }
 
-    public static InstanceOfAssertFactory<ServiceException, ServiceExceptionAssert> instanceOfAssertFactory() {
+    public static InstanceOfAssertFactory<AbstractServiceError, ServiceExceptionAssert> instanceOfAssertFactory() {
         return INSTANCE_OF_ASSERT_FACTORY;
     }
 

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/AssertionsTest.java
@@ -45,7 +45,7 @@ public final class AssertionsTest {
                     throw new RuntimeException("My message");
                 }))
                 .hasMessageContaining(
-                        "com.palantir.conjure.java.api.errors.ServiceException",
+                        "com.palantir.conjure.java.api.errors.AbstractServiceError",
                         "java.lang.RuntimeException",
                         "My message");
     }

--- a/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/conjure/java/api/testing/ServiceExceptionAssertTest.java
@@ -18,13 +18,21 @@ package com.palantir.conjure.java.api.testing;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import org.junit.jupiter.api.Test;
 
 public class ServiceExceptionAssertTest {
+
+    private static class TestEndpointServiceException extends EndpointServiceException {
+        TestEndpointServiceException(ErrorType errorType, Arg<?>... safeArgs) {
+            super(errorType, safeArgs);
+        }
+    }
 
     @Test
     public void testSanity() {
@@ -35,15 +43,33 @@ public class ServiceExceptionAssertTest {
                 .hasType(actualType)
                 .hasArgs(SafeArg.of("a", "b"), UnsafeArg.of("c", "d"));
 
+        Assertions.assertThat(
+                        new TestEndpointServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                .hasCode(actualType.code())
+                .hasType(actualType)
+                .hasArgs(SafeArg.of("a", "b"), UnsafeArg.of("c", "d"));
+
         Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
                 .hasCode(actualType.code())
                 .hasType(actualType)
                 .hasArgs(UnsafeArg.of("c", "d"), SafeArg.of("a", "b")); // Order doesn't matter
 
+        Assertions.assertThat(
+                        new TestEndpointServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                .hasCode(actualType.code())
+                .hasType(actualType)
+                .hasArgs(UnsafeArg.of("c", "d"), SafeArg.of("a", "b")); // Order doesn't matter
+
         Assertions.assertThat(new ServiceException(actualType)).hasNoArgs();
+        Assertions.assertThat(new TestEndpointServiceException(actualType)).hasNoArgs();
 
         assertThatThrownBy(() ->
                         Assertions.assertThat(new ServiceException(actualType)).hasCode(ErrorType.Code.INTERNAL))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining(
+                        "Expected ErrorType.Code to be %s, but found %s", ErrorType.Code.INTERNAL, actualType.code());
+        assertThatThrownBy(() -> Assertions.assertThat(new TestEndpointServiceException(actualType))
+                        .hasCode(ErrorType.Code.INTERNAL))
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining(
                         "Expected ErrorType.Code to be %s, but found %s", ErrorType.Code.INTERNAL, actualType.code());
@@ -52,13 +78,27 @@ public class ServiceExceptionAssertTest {
                         Assertions.assertThat(new ServiceException(actualType)).hasType(ErrorType.INTERNAL))
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected ErrorType to be %s, but found %s", ErrorType.INTERNAL, actualType);
+        assertThatThrownBy(() -> Assertions.assertThat(new TestEndpointServiceException(actualType))
+                        .hasType(ErrorType.INTERNAL))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected ErrorType to be %s, but found %s", ErrorType.INTERNAL, actualType);
 
         assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b")))
                         .hasArgs(SafeArg.of("c", "d")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected safe args to be {c=d}, but found {a=b}");
+        assertThatThrownBy(
+                        () -> Assertions.assertThat(new TestEndpointServiceException(actualType, SafeArg.of("a", "b")))
+                                .hasArgs(SafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected safe args to be {c=d}, but found {a=b}");
 
         assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b")))
+                        .hasArgs(UnsafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected unsafe args to be {c=d}, but found {a=b}");
+        assertThatThrownBy(() -> Assertions.assertThat(
+                                new TestEndpointServiceException(actualType, UnsafeArg.of("a", "b")))
                         .hasArgs(UnsafeArg.of("c", "d")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected unsafe args to be {c=d}, but found {a=b}");
@@ -67,14 +107,27 @@ public class ServiceExceptionAssertTest {
                         .hasNoArgs())
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected no args, but found {a=b}");
+        assertThatThrownBy(
+                        () -> Assertions.assertThat(new TestEndpointServiceException(actualType, SafeArg.of("a", "b")))
+                                .hasNoArgs())
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected no args, but found {a=b}");
 
         assertThatThrownBy(() -> Assertions.assertThat(
                                 new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
                         .hasNoArgs())
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected no args, but found {a=b, c=d}");
+        assertThatThrownBy(() -> Assertions.assertThat(new TestEndpointServiceException(
+                                actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                        .hasNoArgs())
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected no args, but found {a=b, c=d}");
 
         Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                .containsArgs(UnsafeArg.of("a", "b"));
+        Assertions.assertThat(
+                        new TestEndpointServiceException(actualType, UnsafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
                 .containsArgs(UnsafeArg.of("a", "b"));
 
         // Safety matters
@@ -83,13 +136,28 @@ public class ServiceExceptionAssertTest {
                         .containsArgs(UnsafeArg.of("a", "b")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected unsafe args to contain {a=b}, but found {c=d}");
+        assertThatThrownBy(() -> Assertions.assertThat(new TestEndpointServiceException(
+                                actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                        .containsArgs(UnsafeArg.of("a", "b")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected unsafe args to contain {a=b}, but found {c=d}");
 
         assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b")))
                         .containsArgs(SafeArg.of("c", "d")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected safe args to contain {c=d}, but found {a=b}");
+        assertThatThrownBy(
+                        () -> Assertions.assertThat(new TestEndpointServiceException(actualType, SafeArg.of("a", "b")))
+                                .containsArgs(SafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected safe args to contain {c=d}, but found {a=b}");
 
         assertThatThrownBy(() -> Assertions.assertThat(new ServiceException(actualType, UnsafeArg.of("a", "b")))
+                        .containsArgs(UnsafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected unsafe args to contain {c=d}, but found {a=b}");
+        assertThatThrownBy(() -> Assertions.assertThat(
+                                new TestEndpointServiceException(actualType, UnsafeArg.of("a", "b")))
                         .containsArgs(UnsafeArg.of("c", "d")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected unsafe args to contain {c=d}, but found {a=b}");


### PR DESCRIPTION
Do not merge yet. Out of an abundance of caution, I'd like to test this with an RC to validate there are no hiccups with Conjure error handling.

## Before this PR
When #1352 was added, the test utilities to assert properties on the `EndpointServiceException` was not added.

## After this PR
This PR introduces a common abstract base class `AbstractServiceError` which both `ServiceException` and `EndpointServiceException` extend. It also modifies `ServiceExceptionAssert` to use `AbstractServiceError` instead of `ServiceException` in the template variable. 

==COMMIT_MSG==
Add `AbstractServiceError` and extend `ServiceExceptionAssert` to support `EndpointServiceException`
==COMMIT_MSG==

## Possible downsides?
We are making `AbstractServiceError` public so we can use it in the `ServiceExceptionAssert` which lives in a different package. Ideally, `AbstractServiceError` will not be public. A warning not to use the class was added to the docstring.
