### PR TITLE
Expand `ProxyConfiguration#Type` to include `FROM_ENVIRONMENT_NO_PROXY_AWARE`

### DIFF
--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -49,6 +49,12 @@ public abstract class ProxyConfiguration {
         FROM_ENVIRONMENT,
 
         /**
+         * Use an http-proxy with {@link ProxyConfiguration#hostAndPort()} extracted from environment's "https_proxy",
+         * respecting the environment's "no_proxy" setting.
+         */
+        FROM_ENVIRONMENT_NO_PROXY_AWARE,
+
+        /**
          * Use an http-proxy specified by {@link ProxyConfiguration#hostAndPort()} and (optionally)
          * {@link ProxyConfiguration#credentials()}.
          */


### PR DESCRIPTION
## Before this PR
When the `FROM_ENVIRONMENT` proxy type is selected, we do not respect the `no_proxy` environment variable. We would like to start respecting this variable while not breaking existing clients that use `FROM_ENVIRONMENT`. Requiring that clients explicitly select the behavior that respects `no_proxy` allows us to roll the change out safely.

Eventually, we can deprecate the `FROM_ENVIRONMENT` type and remove it.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Expand `ProxyConfiguration#Type` to include `FROM_ENVIRONMENT_NO_PROXY_AWARE`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

