### PR TITLE
Add `ConjureErrorParameterFormat` with utility to encode and parse HTTP header

### DIFF
--- a/changelog/@unreleased/pr-1398.v2.yml
+++ b/changelog/@unreleased/pr-1398.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add `ConjureErrorParameterFormat` with utility to encode and parse
+    HTTP header
+  links:
+  - https://github.com/palantir/conjure-java-runtime-api/pull/1398

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormat.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormat.java
@@ -21,6 +21,14 @@ import com.palantir.logsafe.Safe;
 
 /**
  * A class representing the Conjure error parameter format that a client expects to receive from a server.
+ *
+ * <p>Built-in formats are:
+ * <ul>
+ *   <li>{@link #JSON_FORMAT}: Parameters are expected to be serialized as JSON</li>
+ * </ul>
+ *
+ * <p>Clients should use the utility methods in {@link ConjureErrorParameterFormats} rather than
+ * directly constructing instances of this class.
  */
 @Safe
 public final class ConjureErrorParameterFormat {

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormat.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormat.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+
+/**
+ * A class representing the Conjure error parameter format that a client expects to receive from a server.
+ */
+@Safe
+public final class ConjureErrorParameterFormat {
+    private static final String JSON = "JSON";
+    public static final ConjureErrorParameterFormat JSON_FORMAT = new ConjureErrorParameterFormat(JSON);
+
+    @Safe
+    private final String value;
+
+    private ConjureErrorParameterFormat(@Safe String value) {
+        this.value = Preconditions.checkNotNull(value, "Value is required");
+    }
+
+    static ConjureErrorParameterFormat valueOf(@Safe String value) {
+        Preconditions.checkNotNull(value, "Value is required");
+        if (JSON.equalsIgnoreCase(value)) {
+            return JSON_FORMAT;
+        }
+        return new ConjureErrorParameterFormat(value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        ConjureErrorParameterFormat format = (ConjureErrorParameterFormat) other;
+        return value.equals(format.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
@@ -29,7 +29,8 @@ import java.util.Optional;
  */
 public final class ConjureErrorParameterFormats {
     // The HTTP header name used to specify the expected Conjure error parameter format.
-    private static final String ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER = "Accept-Conjure-Error-Parameter-Format";
+    // VisibleForTesting
+    static final String ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER = "Accept-Conjure-Error-Parameter-Format";
 
     /**
      * Encodes the error parameter format into an outgoing request via HTTP header.

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import com.palantir.logsafe.Preconditions;
+import java.util.Optional;
+
+public final class ConjureErrorParameterFormats {
+    // The HTTP header name used to specify the expected Conjure error parameter format.
+    private static final String ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER = "Accept-Conjure-Error-Parameter-Format";
+
+    public static <T> void encodeToRequest(
+            ConjureErrorParameterFormat format,
+            T request,
+            ConjureErrorParameterFormatRequestEncodingAdapter<? super T> adapter) {
+        Preconditions.checkNotNull(format, "Conjure error parameter format is required");
+        Preconditions.checkNotNull(request, "Request is required");
+        Preconditions.checkNotNull(adapter, "Adapter is required");
+
+        adapter.setHeader(request, ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER, format.toString());
+    }
+
+    public static <T> Optional<ConjureErrorParameterFormat> parseFromRequest(
+            T request, ConjureErrorParameterFormatRequestDecodingAdapter<? super T> adapter) {
+        Preconditions.checkNotNull(request, "Request is required");
+        Preconditions.checkNotNull(adapter, "Adapter is required");
+
+        String headerValue = adapter.getFirstHeader(request, ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER);
+        if (headerValue == null || headerValue.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(ConjureErrorParameterFormat.valueOf(headerValue));
+    }
+
+    public interface ConjureErrorParameterFormatRequestEncodingAdapter<RESPONSE> {
+        void setHeader(RESPONSE response, String headerName, String headerValue);
+    }
+
+    public interface ConjureErrorParameterFormatRequestDecodingAdapter<RESPONSE> {
+        String getFirstHeader(RESPONSE response, String headerName);
+    }
+
+    private ConjureErrorParameterFormats() {}
+}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
@@ -77,12 +77,12 @@ public final class ConjureErrorParameterFormats {
         return Optional.of(ConjureErrorParameterFormat.valueOf(headerValue));
     }
 
-    public interface ConjureErrorParameterFormatRequestEncodingAdapter<RESPONSE> {
-        void setHeader(RESPONSE response, String headerName, String headerValue);
+    public interface ConjureErrorParameterFormatRequestEncodingAdapter<REQUEST> {
+        void setHeader(REQUEST response, String headerName, String headerValue);
     }
 
-    public interface ConjureErrorParameterFormatRequestDecodingAdapter<RESPONSE> {
-        String getFirstHeader(RESPONSE response, String headerName);
+    public interface ConjureErrorParameterFormatRequestDecodingAdapter<REQUEST> {
+        String getFirstHeader(REQUEST response, String headerName);
     }
 
     private ConjureErrorParameterFormats() {}

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
@@ -19,10 +19,29 @@ package com.palantir.conjure.java.api.errors;
 import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 
+/**
+ * Utility methods for encoding and decoding the expected format for Conjure error parameters in HTTP requests.
+ *
+ * <p>This class provides methods for clients to set their expected format for receiving error parameters
+ * from servers, and for servers to parse these preferences from incoming requests.
+ *
+ * <p>The format is transmitted via the {@value #ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER} HTTP header.
+ */
 public final class ConjureErrorParameterFormats {
     // The HTTP header name used to specify the expected Conjure error parameter format.
     private static final String ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER = "Accept-Conjure-Error-Parameter-Format";
 
+    /**
+     * Encodes the error parameter format into an outgoing request via HTTP header.
+     *
+     * <p>This method sets the {@value #ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER} header on the
+     * provided request object using the supplied adapter.
+     *
+     * @param <T> the type of request object
+     * @param format the format for error parameters
+     * @param request the request object to set headers on
+     * @param adapter the adapter for setting headers on the request
+     */
     public static <T> void encodeToRequest(
             ConjureErrorParameterFormat format,
             T request,
@@ -34,6 +53,17 @@ public final class ConjureErrorParameterFormats {
         adapter.setHeader(request, ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER, format.toString());
     }
 
+    /**
+     * Parses the error parameter format from an incoming request's HTTP headers.
+     *
+     * <p>This method reads the {@value #ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER} header from the
+     * provided request object using the supplied adapter.
+     *
+     * @param <T> the type of request object
+     * @param request the request object to read headers from
+     * @param adapter the adapter for reading headers from the request
+     * @return the format for error parameters, or empty if not specified
+     */
     public static <T> Optional<ConjureErrorParameterFormat> parseFromRequest(
             T request, ConjureErrorParameterFormatRequestDecodingAdapter<? super T> adapter) {
         Preconditions.checkNotNull(request, "Request is required");

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormatsTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormatsTest.java
@@ -29,14 +29,13 @@ import org.junit.jupiter.api.Test;
 
 public final class ConjureErrorParameterFormatsTest {
 
-    private static final String HEADER_NAME = "Accept-Conjure-Error-Parameter-Format";
-
     @Test
     public void encodeToRequest_setsHeaderCorrectly() {
         Map<String, String> request = new HashMap<>();
         ConjureErrorParameterFormat format = ConjureErrorParameterFormat.JSON_FORMAT;
         ConjureErrorParameterFormats.encodeToRequest(format, request, Encoder.INSTANCE);
-        assertThat(request).containsEntry(HEADER_NAME, "JSON");
+        assertThat(request)
+                .containsEntry(ConjureErrorParameterFormats.ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER, "JSON");
     }
 
     @Test
@@ -59,7 +58,7 @@ public final class ConjureErrorParameterFormatsTest {
     @Test
     public void parseFromRequest_headerPresent_returnsFormat() {
         Map<String, String> request = new HashMap<>();
-        request.put(HEADER_NAME, "JSON");
+        request.put(ConjureErrorParameterFormats.ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER, "JSON");
         assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE))
                 .contains(ConjureErrorParameterFormat.JSON_FORMAT);
     }
@@ -74,7 +73,7 @@ public final class ConjureErrorParameterFormatsTest {
     @Test
     public void parseFromRequest_headerEmpty_returnsEmpty() {
         Map<String, String> request = new HashMap<>();
-        request.put(HEADER_NAME, "");
+        request.put(ConjureErrorParameterFormats.ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER, "");
         assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE))
                 .isEmpty();
     }
@@ -94,7 +93,7 @@ public final class ConjureErrorParameterFormatsTest {
     @Test
     public void parseFromRequest_customFormat_returnsCorrectFormat() {
         Map<String, String> request = new HashMap<>();
-        request.put(HEADER_NAME, "CUSTOM_FORMAT");
+        request.put(ConjureErrorParameterFormats.ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER, "CUSTOM_FORMAT");
         Optional<ConjureErrorParameterFormat> result =
                 ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE);
         assertThat(result).isPresent();

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormatsTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormatsTest.java
@@ -60,7 +60,7 @@ public final class ConjureErrorParameterFormatsTest {
         Map<String, String> request = new HashMap<>();
         request.put(ConjureErrorParameterFormats.ACCEPT_CONJURE_ERROR_PARAMETER_FORMAT_HEADER, "JSON");
         assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE))
-                .contains(ConjureErrorParameterFormat.JSON_FORMAT);
+                .containsSame(ConjureErrorParameterFormat.JSON_FORMAT);
     }
 
     @Test
@@ -107,7 +107,7 @@ public final class ConjureErrorParameterFormatsTest {
         ConjureErrorParameterFormats.encodeToRequest(originalFormat, request, Encoder.INSTANCE);
         Optional<ConjureErrorParameterFormat> parsedFormat =
                 ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE);
-        assertThat(parsedFormat).contains(originalFormat);
+        assertThat(parsedFormat).containsSame(originalFormat);
     }
 
     private enum Encoder implements ConjureErrorParameterFormatRequestEncodingAdapter<Map<String, String>> {

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormatsTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormatsTest.java
@@ -55,6 +55,7 @@ public final class ConjureErrorParameterFormatsTest {
                 .isInstanceOf(SafeNullPointerException.class)
                 .hasMessage("Adapter is required");
     }
+
     @Test
     public void parseFromRequest_headerPresent_returnsFormat() {
         Map<String, String> request = new HashMap<>();
@@ -66,14 +67,16 @@ public final class ConjureErrorParameterFormatsTest {
     @Test
     public void parseFromRequest_headerMissing_returnsEmpty() {
         Map<String, String> request = new HashMap<>();
-        assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE)).isEmpty();
+        assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE))
+                .isEmpty();
     }
 
     @Test
     public void parseFromRequest_headerEmpty_returnsEmpty() {
         Map<String, String> request = new HashMap<>();
         request.put(HEADER_NAME, "");
-        assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE)).isEmpty();
+        assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE))
+                .isEmpty();
     }
 
     @Test

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormatsTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormatsTest.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormats.ConjureErrorParameterFormatRequestDecodingAdapter;
+import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormats.ConjureErrorParameterFormatRequestEncodingAdapter;
+import com.palantir.logsafe.exceptions.SafeNullPointerException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public final class ConjureErrorParameterFormatsTest {
+
+    private static final String HEADER_NAME = "Accept-Conjure-Error-Parameter-Format";
+
+    @Test
+    public void encodeToRequest_setsHeaderCorrectly() {
+        Map<String, String> request = new HashMap<>();
+        ConjureErrorParameterFormat format = ConjureErrorParameterFormat.JSON_FORMAT;
+        ConjureErrorParameterFormats.encodeToRequest(format, request, Encoder.INSTANCE);
+        assertThat(request).containsEntry(HEADER_NAME, "JSON");
+    }
+
+    @Test
+    public void encodeToRequest_null_checks() {
+        Map<String, String> request = new HashMap<>();
+        assertThatThrownBy(() -> ConjureErrorParameterFormats.encodeToRequest(null, request, Encoder.INSTANCE))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessage("Conjure error parameter format is required");
+
+        ConjureErrorParameterFormat format = ConjureErrorParameterFormat.JSON_FORMAT;
+        assertThatThrownBy(() -> ConjureErrorParameterFormats.encodeToRequest(format, null, Encoder.INSTANCE))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessage("Request is required");
+
+        assertThatThrownBy(() -> ConjureErrorParameterFormats.encodeToRequest(format, request, null))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessage("Adapter is required");
+    }
+    @Test
+    public void parseFromRequest_headerPresent_returnsFormat() {
+        Map<String, String> request = new HashMap<>();
+        request.put(HEADER_NAME, "JSON");
+        assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE))
+                .contains(ConjureErrorParameterFormat.JSON_FORMAT);
+    }
+
+    @Test
+    public void parseFromRequest_headerMissing_returnsEmpty() {
+        Map<String, String> request = new HashMap<>();
+        assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE)).isEmpty();
+    }
+
+    @Test
+    public void parseFromRequest_headerEmpty_returnsEmpty() {
+        Map<String, String> request = new HashMap<>();
+        request.put(HEADER_NAME, "");
+        assertThat(ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE)).isEmpty();
+    }
+
+    @Test
+    public void parseFromRequest_null_checks() {
+        assertThatThrownBy(() -> ConjureErrorParameterFormats.parseFromRequest(null, Decoder.INSTANCE))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessage("Request is required");
+
+        Map<String, String> request = new HashMap<>();
+        assertThatThrownBy(() -> ConjureErrorParameterFormats.parseFromRequest(request, null))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessage("Adapter is required");
+    }
+
+    @Test
+    public void parseFromRequest_customFormat_returnsCorrectFormat() {
+        Map<String, String> request = new HashMap<>();
+        request.put(HEADER_NAME, "CUSTOM_FORMAT");
+        Optional<ConjureErrorParameterFormat> result =
+                ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE);
+        assertThat(result).isPresent();
+        assertThat(result.get().toString()).isEqualTo("CUSTOM_FORMAT");
+    }
+
+    @Test
+    public void roundTrip() {
+        Map<String, String> request = new HashMap<>();
+        ConjureErrorParameterFormat originalFormat = ConjureErrorParameterFormat.JSON_FORMAT;
+        ConjureErrorParameterFormats.encodeToRequest(originalFormat, request, Encoder.INSTANCE);
+        Optional<ConjureErrorParameterFormat> parsedFormat =
+                ConjureErrorParameterFormats.parseFromRequest(request, Decoder.INSTANCE);
+        assertThat(parsedFormat).contains(originalFormat);
+    }
+
+    private enum Encoder implements ConjureErrorParameterFormatRequestEncodingAdapter<Map<String, String>> {
+        INSTANCE;
+
+        @Override
+        public void setHeader(Map<String, String> request, String headerName, String headerValue) {
+            request.put(headerName, headerValue);
+        }
+    }
+
+    private enum Decoder implements ConjureErrorParameterFormatRequestDecodingAdapter<Map<String, String>> {
+        INSTANCE;
+
+        @Override
+        public String getFirstHeader(Map<String, String> request, String headerName) {
+            return request.get(headerName);
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
Currently, error parameters are serialized using `Objects.toString`. We'd like to enable clients to receive JSON parameters as well. In order to safely migrate error parameter serialization formats, clients should be able to specify the parameter format they expect from servers. They are currently not able to do this. 

## After this PR
Introduce a header that clients are able to set when sending requests to servers which specifies the expected format for Conjure error parameters.

==COMMIT_MSG==
Add `ConjureErrorParameterFormat` with utility to encode and parse HTTP header
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

