### PR TITLE
Fix typo in ConjureErrorParameterFormats encoder and decoder adapters

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/ConjureErrorParameterFormats.java
@@ -78,11 +78,11 @@ public final class ConjureErrorParameterFormats {
     }
 
     public interface ConjureErrorParameterFormatRequestEncodingAdapter<REQUEST> {
-        void setHeader(REQUEST response, String headerName, String headerValue);
+        void setHeader(REQUEST request, String headerName, String headerValue);
     }
 
     public interface ConjureErrorParameterFormatRequestDecodingAdapter<REQUEST> {
-        String getFirstHeader(REQUEST response, String headerName);
+        String getFirstHeader(REQUEST request, String headerName);
     }
 
     private ConjureErrorParameterFormats() {}


### PR DESCRIPTION
## Before this PR
Accidentally named a variable `response` when it should've been `request`.

## After this PR
Fix typo in ConjureErrorParameterFormats encoder and decoder adapters.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

