### PR TITLE
Add SerializableErrorProvider

### DIFF
--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableErrorProvider.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableErrorProvider.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.api.errors;
+
+/**
+ * This interface has one method that provides an instance of a class that extends {@link AbstractSerializableError}.
+ * This interface should be implemented by classes that extend {@code RemoteException} and would like to provide access
+ * to a custom serializable error.
+ *<p>
+ * The following is an example of how to implement this interface in a custom exception class:
+ *
+ * <pre>
+ *     {@code
+ *     public final class MyCustomRemoteException extends RemoteException
+ *         implements SerializableErrorProvider<CustomParameters> {
+ *         private final CustomParameters parameters;
+ *
+ *         public ConflictingCauseSafeArgException(MyCustomSerializableError error, int status) {
+ *             super(error.toSerializableError(), status);
+ *             this.error = error;
+ *         }
+ *
+ *         public MyCustomSerializableError error() {
+ *             return error;
+ *         }
+ *     }
+ *     }
+ * </pre>
+ *
+ * where {@code CustomParameters} is a user-defined class representing the error parameters, and
+ * {@code MyCustomSerializableError} is a class extending {@code AbstractSerializableError<CustomParameters>}.
+ */
+public interface SerializableErrorProvider<T> {
+    /**
+     * Provides an instance of a class that extends {@link AbstractSerializableError} with parameter type {@code T}.
+     */
+    AbstractSerializableError<T> error();
+}


### PR DESCRIPTION
## Before this PR

### Problem

In Dialogue's `DefaultClients` implementation, [we wrap the `RemoteException` caught from deserialization logic with a new `RemoteException` to capture the stack trace](https://github.com/palantir/dialogue/blob/c853ce41a049be64582dab90d76c7bc4c3057699/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java#L123-L125). I'd like to do the same thing with custom implementations of `RemoteException`. I need to be able to create the custom remote exception using reflection. 

### Proposed solution
Custom remote exception classes are expected to provide a constructor that takes a `AbstractSerializableError` and an `int`([documented here](https://github.com/palantir/dialogue/pull/2666/files#diff-db7d2953433d4322433e4e38c2794dbce4c55eb0ab231b2f2f513285a6cc271dR96-R97) in ExceptionDeserializerArgs). To invoke this method, I need access to the `AbstractSerializableError`. Instead of _just_ updating docs informing clients that custom exceptions need to implement a `AbstractSerializableError<ParamT> error()` method, I'd like to codify this assumption with an interface, and enforce it at compile time.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add SerializableErrorProvider
==COMMIT_MSG==

## Possible downsides?

