### PR TITLE
Add `parameterMap` to `AbstractSerializableError`

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,23 +1,29 @@
 versionOverrides:
-  com.palantir.conjure.java.api:test-utils:2.8.0: "2.7.0"
-  com.palantir.conjure.java.api:ssl-config:2.8.0: "2.7.0"
   com.palantir.conjure.java.api:errors:2.8.0: "2.7.0"
   com.palantir.conjure.java.api:service-config:2.8.0: "2.7.0"
+  com.palantir.conjure.java.api:ssl-config:2.8.0: "2.7.0"
+  com.palantir.conjure.java.api:test-utils:2.8.0: "2.7.0"
 acceptedBreaks:
   "2.10.0":
     com.palantir.conjure.java.api:service-config:
-    - code: "java.method.addedToInterface"
-      old: null
-      new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.api.config.service.ServiceConfiguration::enableHttp2()"
-      justification: "Added a new field to ServiceConfiguration, @Immutables annotated\
-        \ types are not meant for extension"
-    - code: "java.method.addedToInterface"
-      old: null
-      new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.api.config.service.PartialServiceConfiguration::enableHttp2()"
-      justification: "Added a new field to ServiceConfiguration, @Immutables annotated\
-        \ types are not meant for extension"
     - code: "java.method.abstractMethodAdded"
-      old: null
       new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.api.config.service.ServicesConfigBlock::defaultEnableHttp2()"
       justification: "Added a new field to ServiceConfiguration, @Immutables annotated\
         \ types are not meant for extension"
+    - code: "java.method.addedToInterface"
+      new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.api.config.service.PartialServiceConfiguration::enableHttp2()"
+      justification: "Added a new field to ServiceConfiguration, @Immutables annotated\
+        \ types are not meant for extension"
+    - code: "java.method.addedToInterface"
+      new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.api.config.service.ServiceConfiguration::enableHttp2()"
+      justification: "Added a new field to ServiceConfiguration, @Immutables annotated\
+        \ types are not meant for extension"
+  "2.65.0":
+    com.palantir.conjure.java.api:errors:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void com.palantir.conjure.java.api.errors.AbstractSerializableError<T>::<init>(java.lang.String,\
+        \ java.lang.String, java.lang.String, T)"
+      new: "method void com.palantir.conjure.java.api.errors.AbstractSerializableError<T>::<init>(java.lang.String,\
+        \ java.lang.String, java.lang.String, T, java.util.Map<java.lang.String, java.lang.Object>)"
+      justification: "Adding a method to provide a generic map of parameters. This\
+        \ interfaces is not constructed anywhere yet."

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/AbstractSerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/AbstractSerializableError.java
@@ -16,6 +16,8 @@
 
 package com.palantir.conjure.java.api.errors;
 
+import java.util.Map;
+
 /**
  * Base class for serializable Conjure errors with generic parameter type support.
  * <p>
@@ -43,6 +45,7 @@ public abstract class AbstractSerializableError<T> {
     private final String errorName;
     private final String errorInstanceId;
     private final T parameters;
+    private final Map<String, Object> parameterMap;
 
     public final String errorCode() {
         return errorCode;
@@ -60,10 +63,20 @@ public abstract class AbstractSerializableError<T> {
         return parameters;
     }
 
-    protected AbstractSerializableError(String errorCode, String errorName, String errorInstanceId, T parameters) {
+    public final Map<String, Object> parameterMap() {
+        return parameterMap;
+    }
+
+    protected AbstractSerializableError(
+            String errorCode,
+            String errorName,
+            String errorInstanceId,
+            T parameters,
+            Map<String, Object> parameterMap) {
         this.errorCode = errorCode;
         this.errorName = errorName;
         this.errorInstanceId = errorInstanceId;
         this.parameters = parameters;
+        this.parameterMap = parameterMap;
     }
 }

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/AbstractSerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/AbstractSerializableError.java
@@ -34,7 +34,7 @@ import java.util.Map;
  *         @JsonProperty("errorName") String errorName,
  *         @JsonProperty("errorInstanceId") String errorInstanceId,
  *         @JsonProperty("parameters") CustomErrorParameters parameters) {
- *         super(errorCode, errorName, errorInstanceId, parameters);
+ *         super(errorCode, errorName, errorInstanceId, parameters, Map.of("param1", parameters.param1()));
  *     }
  * }
  * }
@@ -63,6 +63,12 @@ public abstract class AbstractSerializableError<T> {
         return parameters;
     }
 
+    /**
+     * A map of parameter names to their values. Ideally, {@code parameters()} should be used if the specific type
+     * {@code T} is known. For clients that do not know (and do not need to know) the specific type {@code T}, this map
+     * provides a way to access the error parameters. For example, a client may want to access the parameters for any
+     * error and serialize them in a custom format.
+     */
     public final Map<String, Object> parameterMap() {
         return parameterMap;
     }


### PR DESCRIPTION
## Before this PR
Currently, the rich parameter types are only accessible for clients that are aware of the type of the parameters. There is a specific proxy-like use case where clients are not aware of the type of the parameters, and would like to access the parameter map in order to pass it along to a client that does have knowledge of the parameter types.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `parameterMap` to `AbstractSerializableError`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

